### PR TITLE
Add MISTRAL_API_KEY placeholder to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,4 @@ NEO4J_PASSWORD=password
 VITE_API_URL=http://127.0.0.1:5001
 DATABASE_URL=postgresql://flowsint:flowsint@localhost:5433/flowsint
 REDIS_URL=redis://redis:6379/0
+#MISTRAL_API_KEY=<YOUR_MISTRAL_API_KEY>


### PR DESCRIPTION
A commented line serviing as placeholder for MISTRAL_API_KEY.