### PR TITLE
fix(enricher): graceful handling of invalid phone/email in website_to_crawler

### DIFF
--- a/flowsint-enrichers/src/flowsint_enrichers/website/to_crawler.py
+++ b/flowsint-enrichers/src/flowsint_enrichers/website/to_crawler.py
@@ -84,9 +84,21 @@ class WebsiteToCrawler(Enricher):
                             {"message": f"  Found on: {item.source_url}"},
                         )
                     if item.type == "email":
-                        website_result["emails"].append(Email(email=item.value))
+                        try:
+                            website_result["emails"].append(Email(email=item.value))
+                        except Exception as e:
+                            Logger.warn(
+                                self.sketch_id,
+                                {"message": f"Skipping invalid email '{item.value}': {e}"},
+                            )
                     if item.type == "phone":
-                        website_result["phones"].append(Phone(number=item.value))
+                        try:
+                            website_result["phones"].append(Phone(number=item.value))
+                        except Exception as e:
+                            Logger.warn(
+                                self.sketch_id,
+                                {"message": f"Skipping invalid phone '{item.value}': {e}"},
+                            )
 
                 # Log results
                 Logger.info(


### PR DESCRIPTION
## Summary

- Fix crash when `reconcrawl` extracts phone numbers or emails that fail Pydantic validation
- Invalid items are now logged as warnings and skipped instead of crashing the entire crawl
- All valid emails/phones are still collected and graph nodes are created

## Problem

When crawling a website, if `reconcrawl` extracts a phone number or email that fails type validation, the exception bubbles up and:
1. Crashes the crawl for that website
2. Loses ALL previously collected emails and phones
3. Returns an empty result

## Solution

Wrap `Phone()` and `Email()` construction in individual try-except blocks:
- Invalid items → logged with `Logger.warn()` and skipped
- Valid items → collected normally
- Crawl continues regardless of individual validation failures