### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -78,7 +78,7 @@ jobs:
           severity: "CRITICAL,HIGH"
 
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always() && steps.trivy.outcome == 'success'
         with:
           sarif_file: "trivy-frontend.sarif"
@@ -152,7 +152,7 @@ jobs:
           severity: "CRITICAL,HIGH"
 
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always() && steps.trivy.outcome == 'success'
         with:
           sarif_file: "trivy-backend.sarif"


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `github/codeql-action/upload-sarif` | [`v3`](https://github.com/github/codeql-action/upload-sarif/releases/tag/v3) | [`v4`](https://github.com/github/codeql-action/upload-sarif/releases/tag/v4) | [Release](https://github.com/github/codeql-action/upload-sarif/releases/tag/v4) | images.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
