### PR TITLE
Security: Excessively long JWT access token lifetime

### DIFF
--- a/flowsint-core/src/flowsint_core/core/auth.py
+++ b/flowsint-core/src/flowsint_core/core/auth.py
@@ -14,7 +14,7 @@ if not AUTH_SECRET:
         "AUTH_SECRET environment variable is not set. Please set it in your .env file."
     )
 ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 60
+ACCESS_TOKEN_EXPIRE_MINUTES = 15
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 


### PR DESCRIPTION
## Problem

`ACCESS_TOKEN_EXPIRE_MINUTES` is set to `60 * 60` (3600 minutes = 60 hours). Long-lived bearer tokens significantly increase impact of token theft and replay.

**Severity**: `medium`
**File**: `flowsint-core/src/flowsint_core/core/auth.py`

## Solution

Reduce access-token TTL (commonly 5–30 minutes), issue refresh tokens separately, and rotate/revoke tokens on sensitive events.

## Changes

- `flowsint-core/src/flowsint_core/core/auth.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
