### PR TITLE
fix: replace celery container's inherited curl-based healthcheck

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -123,6 +123,14 @@ services:
       - REDIS_URL=redis://redis:6379/0
       - SKIP_MIGRATIONS=true
       - AUTH_SECRET=${AUTH_SECRET}
+    healthcheck:
+      # Celery has no HTTP server — Dockerfile's curl-based healthcheck always fails.
+      # Use celery's own ping primitive instead.
+      test: ["CMD-SHELL", "celery -A flowsint_core.core.celery inspect ping -d celery@$$HOSTNAME || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -123,6 +123,14 @@ services:
       - REDIS_URL=redis://redis:6379/0
       - SKIP_MIGRATIONS=true
       - AUTH_SECRET=${AUTH_SECRET}
+    healthcheck:
+      # Celery has no HTTP server — Dockerfile's curl-based healthcheck always fails.
+      # Use celery's own ping primitive instead.
+      test: ["CMD-SHELL", "celery -A flowsint_core.core.celery inspect ping -d celery@$$HOSTNAME || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary

The celery container inherits the API's Dockerfile-level `HEALTHCHECK CMD curl -f http://localhost:5001/health`. Celery has no HTTP server — it's a worker — so the check always fails and `docker ps` shows celery as `(unhealthy)` even when the worker is happily processing jobs.

Cosmetic in normal operation, but bites in two real ways:
1. Restart policies keyed off health can't distinguish good-unhealthy from bad-unhealthy.
2. Any service that adds `depends_on: celery: condition: service_healthy` refuses to start.

## Fix

Add a service-level `healthcheck:` block on celery in both `docker-compose.prod.yml` and `docker-compose.dev.yml` using celery's own `inspect ping` against the worker's broker. Compose-level overrides the Dockerfile-level, so no Dockerfile change needed.

## Test

Smoke-tested locally on Docker Compose v5.1.2: `flowsint-celery-prod` flips from `(unhealthy)` → `(healthy)` within ~30s of restart, no other changes.

## Test plan

- [ ] `docker compose up -d celery` — container reports healthy within 30s
- [ ] `docker inspect --format '{{.State.Health.Status}}' flowsint-celery-prod` returns `healthy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)