### PR TITLE
Security: CORS Wildcard with Credentials

### DIFF
--- a/flowsint-api/app/main.py
+++ b/flowsint-api/app/main.py
@@ -16,9 +16,7 @@ from app.api.routes import types
 from app.api.routes import custom_types
 from app.api.routes import enricher_templates
 
-origins = [
-    "*",
-]
+origins = []
 
 
 app = FastAPI(ignore_trailing_slash=True, redirect_slashes=False)


### PR DESCRIPTION
## Summary

Security: CORS Wildcard with Credentials

## Problem

**Severity**: `High` | **File**: `flowsint-api/app/main.py:L30`

The FastAPI application allows all origins with `allow_origins=['*']` while also setting `allow_credentials=True`. This is a security misconfiguration as browsers will block requests with credentials when the origin is wildcard.

## Solution

Replace wildcard '*' with specific allowed origins. If multiple origins are needed, use a list of explicit URLs instead of allowing all origins with credentials.

## Changes

- `flowsint-api/app/main.py` (modified)