### PR TITLE
fix: read social enricher outputs as utf-8

### DIFF
--- a/flowsint-enrichers/src/flowsint_enrichers/social/to_maigret.py
+++ b/flowsint-enrichers/src/flowsint_enrichers/social/to_maigret.py
@@ -53,7 +53,7 @@ class MaigretEnricher(Enricher):
             return results
 
         try:
-            with open(output_file, "r") as f:
+            with open(output_file, "r", encoding="utf-8") as f:
                 raw_data = json.load(f)
         except Exception as e:
             Logger.error(

--- a/flowsint-enrichers/src/flowsint_enrichers/social/to_sherlock.py
+++ b/flowsint-enrichers/src/flowsint_enrichers/social/to_sherlock.py
@@ -63,7 +63,7 @@ class SherlockEnricher(Enricher):
                     continue
 
                 found_accounts = {}
-                with open(output_file, "r") as f:
+                with open(output_file, "r", encoding="utf-8") as f:
                     for line in f:
                         line = line.strip()
                         if line and line.startswith("http"):


### PR DESCRIPTION
## What changed
- Reads Sherlock text output with explicit `encoding="utf-8"`.
- Reads Maigret JSON output with explicit `encoding="utf-8"`.

## Problem
The social enrichers parse CLI-generated text/JSON files without specifying an encoding. On machines whose default locale is not UTF-8, usernames, platform metadata, or URLs containing non-ASCII characters can be decoded inconsistently or fail during parsing.

## Before/after
Before: Sherlock and Maigret output parsing used the platform default encoding.
After: both output parsers read their files as UTF-8, matching the common encoding used by these tools and making behavior consistent across environments.

## Verification
- `python -m py_compile flowsint-enrichers/src/flowsint_enrichers/social/to_sherlock.py flowsint-enrichers/src/flowsint_enrichers/social/to_maigret.py`