### PR TITLE
feat(enrichers): add ip_to_security_risk — Shodan-backed weighted risk scoring for IP nodes

### DIFF
--- a/flowsint-enrichers/pyproject.toml
+++ b/flowsint-enrichers/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "reconcrawl",
     "reconspread",
     "dnspython>=2.4,<3.0",
+    "shodan>=1.31,<2.0",
 ]
 
 [dependency-groups]

--- a/flowsint-enrichers/src/flowsint_enrichers/ip/to_security_risk.py
+++ b/flowsint-enrichers/src/flowsint_enrichers/ip/to_security_risk.py
@@ -1,0 +1,491 @@
+import datetime
+from typing import Any, Dict, List, Optional
+
+from flowsint_core.core.enricher_base import Enricher
+from flowsint_core.core.logger import Logger
+from flowsint_enrichers.registry import flowsint_enricher
+from flowsint_types.ip import Ip
+from flowsint_types.port import Port
+from flowsint_types.risk_profile import RiskProfile
+
+
+# Scoring weights (sum to 1.0)
+_CVSS_W = 0.35
+_EXPOSURE_W = 0.25
+_SENSITIVITY_W = 0.25
+_EXPLOIT_W = 0.15
+
+# Factor lookup tables (mirrors RedFlag triage.py)
+_EXPOSURE_SCORES: Dict[str, float] = {
+    "internet_facing": 100.0,
+    "partner": 60.0,
+    "internal": 30.0,
+    "unknown": 50.0,
+}
+
+_EXPLOIT_SCORES: Dict[str, float] = {
+    "active_exploitation": 100.0,
+    "public_exploit": 65.0,
+    "no_exploit": 10.0,
+    "unknown": 30.0,
+}
+
+# Sensitivity always UNKNOWN here (no asset-inventory layer)
+_SENSITIVITY_UNKNOWN = 50.0
+
+# Evidence strength multipliers
+_EVIDENCE_MULTIPLIERS: Dict[str, float] = {
+    "correlated": 0.95,   # Shodan has CVEs + confirms port
+    "inferred": 0.85,     # Shodan data only, no CVE cross-reference
+    "unknown": 0.90,      # Shodan host found but minimal data
+}
+
+# Services whose presence on the internet signals INTERNET_FACING exposure
+_INTERNET_FACING_SERVICES = {
+    "http", "https", "ftp", "ssh", "rdp", "telnet",
+    "smtp", "pop3", "imap", "dns", "mqtt", "vnc",
+    "mssql", "mysql", "postgresql", "mongodb", "redis",
+    "elasticsearch", "memcached", "cassandra",
+}
+
+# Risk-level bands matching RedFlag deal-tier mapping
+def _risk_level(score: float) -> str:
+    if score >= 75:
+        return "critical"
+    if score >= 50:
+        return "high"
+    if score >= 25:
+        return "medium"
+    return "low"
+
+
+def _compute_risk_score(
+    max_cvss: float,
+    exposure: str,
+    exploit_status: str,
+    evidence: str,
+) -> float:
+    """
+    Weighted risk score (0–100) adapted from RedFlag's triage model.
+
+    score = (cvss_norm * 0.35) + (exposure * 0.25) + (sensitivity * 0.25) + (exploit * 0.15)
+    then multiplied by evidence-strength multiplier.
+    """
+    cvss_norm = (max_cvss / 10.0) * 100.0
+    base = (
+        cvss_norm * _CVSS_W
+        + _EXPOSURE_SCORES.get(exposure, 50.0) * _EXPOSURE_W
+        + _SENSITIVITY_UNKNOWN * _SENSITIVITY_W
+        + _EXPLOIT_SCORES.get(exploit_status, 30.0) * _EXPLOIT_W
+    )
+    return round(min(base * _EVIDENCE_MULTIPLIERS.get(evidence, 0.90), 100.0), 2)
+
+
+@flowsint_enricher
+class IpToSecurityRisk(Enricher):
+    """
+    [Shodan] Cybersecurity risk assessment for an IP address.
+
+    Queries Shodan for open ports, banners, CVEs, and host metadata, then applies
+    a weighted risk-scoring model (CVSS × exposure × exploit status × evidence
+    strength) to produce a 0–100 risk score with critical / high / medium / low
+    classification.
+
+    The scoring formula is adapted from RedFlag, an M&A due-diligence tool:
+        score = (cvss_normalised * 0.35)
+              + (exposure_score  * 0.25)
+              + (sensitivity_score * 0.25)   # always 50 — no asset-inventory layer
+              + (exploit_score   * 0.15)
+        then multiplied by an evidence-strength multiplier (0.85 – 0.95).
+
+    Exposure is inferred from open port/service names:
+        • INTERNET_FACING (100) — HTTP, HTTPS, SSH, RDP, FTP, SMTP, databases, etc.
+        • UNKNOWN (50) — service not in known internet-facing list
+
+    Evidence strength:
+        • CORRELATED (×0.95) — Shodan has CVEs AND confirms the port is open
+        • INFERRED   (×0.85) — Shodan host data found but no linked CVEs
+        • UNKNOWN    (×0.90) — Shodan returned minimal data
+
+    Outputs one RiskProfile node per IP and creates Port nodes for every open
+    port Shodan reports.  Graph relationships created:
+        (Ip) -[HAS_RISK_PROFILE]-> (RiskProfile)
+        (Ip) -[HAS_PORT]->         (Port)
+    """
+
+    InputType = Ip
+    OutputType = RiskProfile
+
+    def __init__(
+        self,
+        sketch_id: Optional[str] = None,
+        scan_id: Optional[str] = None,
+        vault=None,
+        params: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__(
+            sketch_id=sketch_id,
+            scan_id=scan_id,
+            params_schema=self.get_params_schema(),
+            vault=vault,
+            params=params,
+        )
+
+    @classmethod
+    def get_params_schema(cls) -> List[Dict[str, Any]]:
+        return [
+            {
+                "name": "SHODAN_API_KEY",
+                "type": "vaultSecret",
+                "description": "Shodan API key (1 credit per IP lookup).",
+                "required": True,
+            },
+        ]
+
+    @classmethod
+    def required_params(cls) -> bool:
+        return True
+
+    @classmethod
+    def name(cls) -> str:
+        return "ip_to_security_risk"
+
+    @classmethod
+    def category(cls) -> str:
+        return "Ip"
+
+    @classmethod
+    def key(cls) -> str:
+        return "address"
+
+    @classmethod
+    def documentation(cls) -> str:
+        return """
+## IP Security Risk Enricher
+
+Performs a Shodan-backed security risk assessment on an IP address and scores
+the result using a weighted model adapted from [RedFlag](https://github.com/adityaa206/redflag),
+a cybersecurity M&A due-diligence tool.
+
+### What it does
+1. Looks up the IP in Shodan (`api.host()` — 1 credit per call).
+2. Extracts open ports, service banners, CVE IDs, ASN, org, and geolocation.
+3. Determines *exposure* (INTERNET_FACING vs UNKNOWN) from the service names
+   on open ports.
+4. Determines *exploit status* (PUBLIC_EXPLOIT vs UNKNOWN) from the presence
+   of Shodan-linked CVEs.
+5. Computes a **0–100 risk score** using the formula:
+
+   ```
+   score = (cvss_norm×0.35) + (exposure×0.25) + (sensitivity×0.25) + (exploit×0.15)
+           × evidence_multiplier
+   ```
+
+6. Classifies the score into **critical / high / medium / low**.
+7. Emits a `RiskProfile` node linked to the IP, plus a `Port` node for every
+   open port Shodan reports.
+
+### Required vault secret
+| Key | Source |
+|-----|--------|
+| `SHODAN_API_KEY` | https://account.shodan.io |
+
+### Scoring reference
+| Factor | Value | Score |
+|--------|-------|-------|
+| Exposure | Internet-facing | 100 |
+| Exposure | Unknown | 50 |
+| Exploit | Public CVE | 65 |
+| Exploit | Unknown | 30 |
+| Evidence | Correlated (CVEs + port) | ×0.95 |
+| Evidence | Inferred (host only) | ×0.85 |
+
+### Graph output
+```
+(Ip) -[HAS_RISK_PROFILE]-> (RiskProfile)
+(Ip) -[HAS_PORT]->         (Port)
+```
+        """
+
+    # ------------------------------------------------------------------
+    # Core enricher methods
+    # ------------------------------------------------------------------
+
+    async def scan(self, data: List[Ip]) -> List[RiskProfile]:
+        results: List[RiskProfile] = []
+
+        api_key = self.get_secret("SHODAN_API_KEY")
+        if not api_key:
+            Logger.error(
+                self.sketch_id,
+                {"message": "[SecurityRisk] SHODAN_API_KEY is not configured in the vault."},
+            )
+            return results
+
+        # Import here so missing optional dep doesn't break the whole enricher package
+        try:
+            import shodan
+        except ImportError:
+            Logger.error(
+                self.sketch_id,
+                {"message": "[SecurityRisk] 'shodan' Python package is not installed. Run: pip install shodan"},
+            )
+            return results
+
+        api = shodan.Shodan(api_key)
+
+        for ip_obj in data:
+            address = ip_obj.address
+            Logger.info(
+                self.sketch_id,
+                {"message": f"[SecurityRisk] Querying Shodan for {address}…"},
+            )
+            try:
+                host = api.host(address)
+            except shodan.APIError as exc:
+                Logger.warn(
+                    self.sketch_id,
+                    {"message": f"[SecurityRisk] Shodan lookup failed for {address}: {exc}"},
+                )
+                continue
+            except Exception as exc:
+                Logger.error(
+                    self.sketch_id,
+                    {"message": f"[SecurityRisk] Unexpected error for {address}: {exc}"},
+                )
+                continue
+
+            risk_profile = self._build_risk_profile(address, host)
+            results.append(risk_profile)
+
+            Logger.info(
+                self.sketch_id,
+                {
+                    "message": (
+                        f"[SecurityRisk] {address} → score={risk_profile.overall_risk_score}, "
+                        f"level={risk_profile.risk_level}, "
+                        f"ports={len(getattr(risk_profile, '_shodan_ports', []))}"
+                    )
+                },
+            )
+
+        return results
+
+    def postprocess(
+        self, results: List[RiskProfile], input_data: List[Ip] = None
+    ) -> List[RiskProfile]:
+        if not self._graph_service or not results:
+            return results
+
+        ip_map: Dict[str, Ip] = {}
+        if input_data:
+            for ip_obj in input_data:
+                ip_map[ip_obj.address] = ip_obj
+
+        for profile in results:
+            ip_address: str = profile.entity_id
+            ip_obj = ip_map.get(ip_address, Ip(address=ip_address))
+
+            # Persist IP and RiskProfile nodes
+            self.create_node(ip_obj)
+            self.create_node(profile)
+            self.create_relationship(ip_obj, profile, "HAS_RISK_PROFILE")
+            self.log_graph_message(
+                f"[SecurityRisk] {ip_address}: risk={profile.risk_level} "
+                f"({profile.overall_risk_score}/100)"
+            )
+
+            # Persist Port nodes from stored Shodan data
+            shodan_ports: List[Dict[str, Any]] = getattr(profile, "_shodan_ports", [])
+            for port_data in shodan_ports:
+                try:
+                    port_node = Port(
+                        number=port_data["number"],
+                        protocol=port_data.get("protocol", "tcp").upper(),
+                        state="open",
+                        service=port_data.get("service"),
+                        banner=port_data.get("banner"),
+                    )
+                    self.create_node(port_node)
+                    self.create_relationship(ip_obj, port_node, "HAS_PORT")
+                except Exception as exc:
+                    Logger.warn(
+                        self.sketch_id,
+                        {"message": f"[SecurityRisk] Could not create Port node {port_data}: {exc}"},
+                    )
+
+            # Clean up temporary attribute
+            if hasattr(profile, "_shodan_ports"):
+                try:
+                    delattr(profile, "_shodan_ports")
+                except Exception:
+                    pass
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _build_risk_profile(self, address: str, host: Dict[str, Any]) -> RiskProfile:
+        """Parse a raw Shodan host response into a scored RiskProfile."""
+
+        # ── Collect open ports ────────────────────────────────────────
+        shodan_ports: List[Dict[str, Any]] = []
+        service_names: set = set()
+
+        for banner in host.get("data", []):
+            port_num = banner.get("port")
+            if port_num is None:
+                continue
+            transport = banner.get("transport", "tcp")
+            product = banner.get("product", "")
+            svc = (banner.get("_shodan", {}).get("module", "") or product or "").lower()
+            raw_banner = banner.get("data", "").strip()[:200]  # cap banner length
+
+            shodan_ports.append(
+                {
+                    "number": port_num,
+                    "protocol": transport,
+                    "service": svc or None,
+                    "banner": raw_banner or None,
+                }
+            )
+            if svc:
+                service_names.add(svc)
+
+        # Fallback: use numeric port list when no banner data
+        if not shodan_ports:
+            for p in host.get("ports", []):
+                shodan_ports.append({"number": p, "protocol": "tcp", "service": None, "banner": None})
+
+        # ── CVEs ──────────────────────────────────────────────────────
+        raw_vulns: Dict[str, Any] = host.get("vulns", {})
+        cve_ids: List[str] = sorted(raw_vulns.keys())
+        max_cvss = 0.0
+        for cve_id, cve_meta in raw_vulns.items():
+            cvss = cve_meta.get("cvss", 0.0) or 0.0
+            if cvss > max_cvss:
+                max_cvss = float(cvss)
+
+        # Floor CVSS at 6.5 when CVEs are present (matches RedFlag's Shodan enricher)
+        if cve_ids and max_cvss < 6.5:
+            max_cvss = 6.5
+
+        # ── Exposure ──────────────────────────────────────────────────
+        open_port_numbers = {p["number"] for p in shodan_ports}
+        is_internet_facing = bool(service_names & _INTERNET_FACING_SERVICES) or bool(
+            open_port_numbers & {21, 22, 23, 25, 53, 80, 110, 143, 443, 445, 3306, 3389, 5432, 6379, 8080, 8443, 9200, 27017}
+        )
+        exposure = "internet_facing" if is_internet_facing else "unknown"
+
+        # ── Exploit / evidence ────────────────────────────────────────
+        if cve_ids:
+            exploit_status = "public_exploit"
+            evidence = "correlated"
+        else:
+            exploit_status = "unknown"
+            evidence = "inferred" if shodan_ports else "unknown"
+
+        # ── Risk score ────────────────────────────────────────────────
+        risk_score = _compute_risk_score(max_cvss, exposure, exploit_status, evidence)
+        level = _risk_level(risk_score)
+
+        # ── Risk factors (human-readable) ─────────────────────────────
+        risk_factors: List[str] = []
+        if is_internet_facing:
+            risk_factors.append(f"Internet-facing ({len(open_port_numbers)} open ports)")
+        if cve_ids:
+            risk_factors.append(f"{len(cve_ids)} CVE(s) linked by Shodan (max CVSS {max_cvss})")
+        if max_cvss >= 9.0:
+            risk_factors.append("Critical-severity CVE (CVSS ≥ 9.0)")
+        if 3389 in open_port_numbers:
+            risk_factors.append("RDP exposed (port 3389)")
+        if 22 in open_port_numbers:
+            risk_factors.append("SSH exposed (port 22)")
+        if open_port_numbers & {3306, 5432, 27017, 6379, 9200}:
+            risk_factors.append("Database port(s) exposed to internet")
+
+        # ── Mitigation recommendations ────────────────────────────────
+        mitigations: List[str] = []
+        if 3389 in open_port_numbers:
+            mitigations.append("Restrict RDP (3389) to VPN or specific IP ranges")
+        if 22 in open_port_numbers:
+            mitigations.append("Disable password auth on SSH; use key-based auth")
+        if open_port_numbers & {3306, 5432, 27017, 6379, 9200}:
+            mitigations.append("Place databases behind firewall; never expose directly to internet")
+        if cve_ids:
+            mitigations.append(f"Patch or mitigate: {', '.join(cve_ids[:5])}")
+        if not mitigations:
+            mitigations.append("Conduct periodic attack-surface review")
+
+        # ── Compliance risks ──────────────────────────────────────────
+        compliance_risks: List[str] = []
+        if cve_ids and max_cvss >= 7.0:
+            compliance_risks.append("Unpatched high-severity CVEs may violate PCI-DSS §6.3.3 / ISO 27001 A.12.6.1")
+        if open_port_numbers & {3306, 5432, 27017}:
+            compliance_risks.append("Internet-exposed database ports may breach GDPR data-protection obligations")
+
+        # ── Metadata from Shodan ──────────────────────────────────────
+        org = host.get("org") or host.get("isp")
+        asn = host.get("asn")
+        country = host.get("country_name")
+        city = host.get("city")
+        hostnames = host.get("hostnames", [])
+        domains = host.get("domains", [])
+
+        exposure_surface_parts = []
+        if org:
+            exposure_surface_parts.append(f"Org: {org}")
+        if asn:
+            exposure_surface_parts.append(f"ASN: {asn}")
+        if country:
+            location = f"{city}, {country}" if city else country
+            exposure_surface_parts.append(f"Location: {location}")
+        if hostnames:
+            exposure_surface_parts.append(f"Hostnames: {', '.join(hostnames[:3])}")
+        if domains:
+            exposure_surface_parts.append(f"Domains: {', '.join(domains[:3])}")
+        if open_port_numbers:
+            exposure_surface_parts.append(f"Open ports: {', '.join(str(p) for p in sorted(open_port_numbers))}")
+
+        exposure_surface = " | ".join(exposure_surface_parts) if exposure_surface_parts else None
+
+        attack_vectors: List[str] = []
+        if cve_ids:
+            attack_vectors.append("Known CVE exploitation")
+        if is_internet_facing:
+            attack_vectors.append("Direct internet attack surface")
+        if open_port_numbers & {21, 23}:
+            attack_vectors.append("Cleartext protocol interception (FTP/Telnet)")
+        if 445 in open_port_numbers:
+            attack_vectors.append("SMB/ransomware lateral movement")
+
+        now_iso = datetime.datetime.utcnow().isoformat() + "Z"
+
+        profile = RiskProfile(
+            entity_id=address,
+            entity_type="IP",
+            overall_risk_score=risk_score,
+            risk_level=level,
+            assessment_date=now_iso,
+            last_updated=now_iso,
+            risk_factors=risk_factors or None,
+            attack_vectors=attack_vectors or None,
+            vulnerabilities=cve_ids or None,
+            exposure_surface=exposure_surface,
+            compliance_risks=compliance_risks or None,
+            mitigation_strategies=mitigations or None,
+            source="Shodan",
+            confidence=0.85 if cve_ids else 0.70,
+        )
+
+        # Stash port data for postprocess (temp attribute, not a Pydantic field)
+        object.__setattr__(profile, "_shodan_ports", shodan_ports)
+
+        return profile
+
+
+# Make types available at module level
+InputType = IpToSecurityRisk.InputType
+OutputType = IpToSecurityRisk.OutputType

--- a/flowsint-enrichers/src/flowsint_enrichers/ip/to_security_risk.py
+++ b/flowsint-enrichers/src/flowsint_enrichers/ip/to_security_risk.py
@@ -1,5 +1,8 @@
 import datetime
-from typing import Any, Dict, List, Optional
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
 
 from flowsint_core.core.enricher_base import Enricher
 from flowsint_core.core.logger import Logger
@@ -7,6 +10,15 @@ from flowsint_enrichers.registry import flowsint_enricher
 from flowsint_types.ip import Ip
 from flowsint_types.port import Port
 from flowsint_types.risk_profile import RiskProfile
+
+
+# NVD API v2 — authoritative CVSS scores per CVE ID
+_NVD_BASE_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0"
+# Used ONLY as a last resort when both Shodan and NVD fail to provide a score
+_NVD_FALLBACK_CVSS = 6.5
+# Rate-limit delays: NVD allows 5 req/30s unauthenticated, 50 req/30s with key
+_NVD_DELAY_NO_KEY = 6.1   # seconds between requests without an API key
+_NVD_DELAY_WITH_KEY = 0.7  # seconds between requests with an API key
 
 
 # Scoring weights (sum to 1.0)
@@ -81,6 +93,94 @@ def _compute_risk_score(
     return round(min(base * _EVIDENCE_MULTIPLIERS.get(evidence, 0.90), 100.0), 2)
 
 
+def _fetch_nvd_cvss(cve_id: str, api_key: Optional[str] = None) -> Optional[float]:
+    """
+    Query NVD API v2 for the real CVSS base score of a CVE.
+
+    Priority order: CVSSv3.1 → CVSSv3.0 → CVSSv2.
+    Returns None if the CVE is not found or the request fails.
+    """
+    headers: Dict[str, str] = {}
+    if api_key:
+        headers["apiKey"] = api_key
+
+    def _do_request() -> Optional[float]:
+        resp = requests.get(
+            _NVD_BASE_URL,
+            params={"cveId": cve_id},
+            headers=headers,
+            timeout=10,
+        )
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        data = resp.json()
+
+        vulns = data.get("vulnerabilities", [])
+        if not vulns:
+            return None
+
+        metrics = vulns[0].get("cve", {}).get("metrics", {})
+        for metric_key in ("cvssMetricV31", "cvssMetricV30", "cvssMetricV2"):
+            for entry in metrics.get(metric_key, []):
+                score = entry.get("cvssData", {}).get("baseScore")
+                if score is not None:
+                    return float(score)
+        return None
+
+    try:
+        return _do_request()
+    except requests.HTTPError as exc:
+        if exc.response is not None and exc.response.status_code == 429:
+            # Rate-limited — wait the full window and retry once
+            time.sleep(30)
+            try:
+                return _do_request()
+            except Exception:
+                return None
+        return None
+    except Exception:
+        return None
+
+
+def _resolve_cvss_scores(
+    raw_vulns: Dict[str, Any],
+    nvd_api_key: Optional[str] = None,
+) -> Tuple[Dict[str, float], float]:
+    """
+    Build a {cve_id: cvss_score} map using real scores from Shodan where
+    available, and NVD API v2 where Shodan's value is missing or zero.
+
+    Returns (cvss_per_cve, max_cvss).
+
+    Fallback chain per CVE:
+        1. Shodan-provided score (if > 0)
+        2. NVD API v2 lookup
+        3. _NVD_FALLBACK_CVSS (6.5) — only if both above fail
+    """
+    delay = _NVD_DELAY_WITH_KEY if nvd_api_key else _NVD_DELAY_NO_KEY
+    cvss_per_cve: Dict[str, float] = {}
+
+    for cve_id, meta in raw_vulns.items():
+        shodan_score = float(meta.get("cvss") or 0.0)
+
+        if shodan_score > 0.0:
+            cvss_per_cve[cve_id] = shodan_score
+        else:
+            # Shodan didn't give us a real score — ask NVD
+            nvd_score = _fetch_nvd_cvss(cve_id, nvd_api_key)
+            if nvd_score is not None:
+                cvss_per_cve[cve_id] = nvd_score
+            else:
+                # NVD also failed (network error, unknown CVE, etc.)
+                cvss_per_cve[cve_id] = _NVD_FALLBACK_CVSS
+
+            time.sleep(delay)
+
+    max_cvss = max(cvss_per_cve.values(), default=0.0)
+    return cvss_per_cve, max_cvss
+
+
 @flowsint_enricher
 class IpToSecurityRisk(Enricher):
     """
@@ -140,6 +240,16 @@ class IpToSecurityRisk(Enricher):
                 "description": "Shodan API key (1 credit per IP lookup).",
                 "required": True,
             },
+            {
+                "name": "NVD_API_KEY",
+                "type": "vaultSecret",
+                "description": (
+                    "NVD API key (optional). Without it, NVD lookups are rate-limited "
+                    "to 5 req/30s which adds ~6s per CVE with a missing Shodan score. "
+                    "Get a free key at https://nvd.nist.gov/developers/request-an-api-key"
+                ),
+                "required": False,
+            },
         ]
 
     @classmethod
@@ -185,10 +295,18 @@ a cybersecurity M&A due-diligence tool.
 7. Emits a `RiskProfile` node linked to the IP, plus a `Port` node for every
    open port Shodan reports.
 
-### Required vault secret
-| Key | Source |
-|-----|--------|
-| `SHODAN_API_KEY` | https://account.shodan.io |
+### Vault secrets
+| Key | Required | Source |
+|-----|----------|--------|
+| `SHODAN_API_KEY` | Yes | https://account.shodan.io (1 credit per `api.host()` call) |
+| `NVD_API_KEY` | No | https://nvd.nist.gov/developers/request-an-api-key |
+
+Shodan often returns CVE IDs with a missing or zero CVSS score.  When that
+happens this enricher automatically queries the **NVD API v2** for the real
+`baseScore` (CVSSv3.1 → CVSSv3.0 → CVSSv2 in priority order).  Without an NVD
+API key, requests are rate-limited to 5/30s which adds ~6 s per affected CVE.
+With a key the limit rises to 50/30s (≈0.7 s per CVE).  Only if NVD also
+fails to return a score does it fall back to a conservative default of 6.5.
 
 ### Scoring reference
 | Factor | Value | Score |
@@ -233,6 +351,7 @@ a cybersecurity M&A due-diligence tool.
             return results
 
         api = shodan.Shodan(api_key)
+        nvd_api_key = self.get_secret("NVD_API_KEY")
 
         for ip_obj in data:
             address = ip_obj.address
@@ -255,7 +374,21 @@ a cybersecurity M&A due-diligence tool.
                 )
                 continue
 
-            risk_profile = self._build_risk_profile(address, host)
+            # Resolve real CVSS scores — Shodan first, NVD for anything missing
+            raw_vulns: Dict[str, Any] = host.get("vulns", {})
+            if raw_vulns:
+                Logger.info(
+                    self.sketch_id,
+                    {
+                        "message": (
+                            f"[SecurityRisk] Resolving CVSS for {len(raw_vulns)} CVE(s) "
+                            f"on {address} via NVD where Shodan score is missing…"
+                        )
+                    },
+                )
+            cvss_per_cve, max_cvss = _resolve_cvss_scores(raw_vulns, nvd_api_key)
+
+            risk_profile = self._build_risk_profile(address, host, cvss_per_cve, max_cvss)
             results.append(risk_profile)
 
             Logger.info(
@@ -327,8 +460,18 @@ a cybersecurity M&A due-diligence tool.
     # Private helpers
     # ------------------------------------------------------------------
 
-    def _build_risk_profile(self, address: str, host: Dict[str, Any]) -> RiskProfile:
-        """Parse a raw Shodan host response into a scored RiskProfile."""
+    def _build_risk_profile(
+        self,
+        address: str,
+        host: Dict[str, Any],
+        cvss_per_cve: Dict[str, float],
+        max_cvss: float,
+    ) -> RiskProfile:
+        """
+        Build a scored RiskProfile from a Shodan host dict and pre-resolved
+        CVSS scores.  cvss_per_cve and max_cvss come from _resolve_cvss_scores()
+        so every score here is real — sourced from Shodan or NVD, not a guess.
+        """
 
         # ── Collect open ports ────────────────────────────────────────
         shodan_ports: List[Dict[str, Any]] = []
@@ -359,18 +502,8 @@ a cybersecurity M&A due-diligence tool.
             for p in host.get("ports", []):
                 shodan_ports.append({"number": p, "protocol": "tcp", "service": None, "banner": None})
 
-        # ── CVEs ──────────────────────────────────────────────────────
-        raw_vulns: Dict[str, Any] = host.get("vulns", {})
-        cve_ids: List[str] = sorted(raw_vulns.keys())
-        max_cvss = 0.0
-        for cve_id, cve_meta in raw_vulns.items():
-            cvss = cve_meta.get("cvss", 0.0) or 0.0
-            if cvss > max_cvss:
-                max_cvss = float(cvss)
-
-        # Floor CVSS at 6.5 when CVEs are present (matches RedFlag's Shodan enricher)
-        if cve_ids and max_cvss < 6.5:
-            max_cvss = 6.5
+        # ── CVEs (already resolved by _resolve_cvss_scores) ──────────
+        cve_ids: List[str] = sorted(cvss_per_cve.keys())
 
         # ── Exposure ──────────────────────────────────────────────────
         open_port_numbers = {p["number"] for p in shodan_ports}
@@ -396,7 +529,10 @@ a cybersecurity M&A due-diligence tool.
         if is_internet_facing:
             risk_factors.append(f"Internet-facing ({len(open_port_numbers)} open ports)")
         if cve_ids:
-            risk_factors.append(f"{len(cve_ids)} CVE(s) linked by Shodan (max CVSS {max_cvss})")
+            # Show real per-CVE scores (top 3 by severity)
+            top_cves = sorted(cvss_per_cve.items(), key=lambda x: x[1], reverse=True)[:3]
+            top_str = ", ".join(f"{cid} ({score})" for cid, score in top_cves)
+            risk_factors.append(f"{len(cve_ids)} CVE(s): {top_str}")
         if max_cvss >= 9.0:
             risk_factors.append("Critical-severity CVE (CVSS ≥ 9.0)")
         if 3389 in open_port_numbers:

--- a/flowsint-enrichers/tests/enrichers/test_ip_to_security_risk.py
+++ b/flowsint-enrichers/tests/enrichers/test_ip_to_security_risk.py
@@ -3,31 +3,36 @@ Tests for the ip_to_security_risk enricher.
 
 Coverage:
 - Pure scoring helpers (_compute_risk_score, _risk_level)
-- _build_risk_profile: various Shodan response shapes
-- scan(): happy path, missing API key, Shodan errors
+- NVD API helpers (_fetch_nvd_cvss, _resolve_cvss_scores)
+- _build_risk_profile: various Shodan response shapes with pre-resolved scores
+- scan(): happy path, missing API key, Shodan errors, NVD integration
 - postprocess(): graph node/relationship creation
-- Vault integration: SHODAN_API_KEY resolution and missing-key error
+- Vault integration: SHODAN_API_KEY + NVD_API_KEY resolution
 """
 
 import uuid
 from typing import Any, Dict
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
+import requests as requests_lib
 
 from flowsint_enrichers.ip.to_security_risk import (
     IpToSecurityRisk,
     InputType,
     OutputType,
-    _EVIDENCE_MULTIPLIERS,
-    _EXPOSURE_SCORES,
-    _EXPLOIT_SCORES,
-    _SENSITIVITY_UNKNOWN,
     _CVSS_W,
-    _EXPOSURE_W,
-    _SENSITIVITY_W,
+    _EVIDENCE_MULTIPLIERS,
+    _EXPLOIT_SCORES,
     _EXPLOIT_W,
+    _EXPOSURE_SCORES,
+    _EXPOSURE_W,
+    _NVD_FALLBACK_CVSS,
+    _SENSITIVITY_UNKNOWN,
+    _SENSITIVITY_W,
     _compute_risk_score,
+    _fetch_nvd_cvss,
+    _resolve_cvss_scores,
     _risk_level,
 )
 from flowsint_types.ip import Ip
@@ -85,6 +90,10 @@ SHODAN_RICH: Dict[str, Any] = {
     },
 }
 
+# CVSS_RICH_MAP is the pre-resolved version of SHODAN_RICH's vulns
+CVSS_RICH_MAP: Dict[str, float] = {"CVE-2021-44228": 10.0, "CVE-2021-45046": 9.0}
+CVSS_RICH_MAX = 10.0
+
 SHODAN_NO_CVES: Dict[str, Any] = {
     "ip_str": "5.6.7.8",
     "org": "Some ISP",
@@ -133,6 +142,7 @@ SHODAN_RDP_EXPOSED: Dict[str, Any] = {
     "vulns": {},
 }
 
+# CVE with CVSS=0 from Shodan — needs NVD lookup
 SHODAN_CVSS_ZERO: Dict[str, Any] = {
     "ip_str": "3.4.5.6",
     "ports": [80],
@@ -150,26 +160,35 @@ SHODAN_CVSS_ZERO: Dict[str, Any] = {
     },
 }
 
+# NVD API v2 response shape helpers
+def _nvd_response(cve_id: str, v31: float = None, v30: float = None, v2: float = None) -> dict:
+    """Build a minimal NVD API v2 JSON response."""
+    metrics: Dict[str, Any] = {}
+    if v31 is not None:
+        metrics["cvssMetricV31"] = [{"cvssData": {"baseScore": v31}}]
+    if v30 is not None:
+        metrics["cvssMetricV30"] = [{"cvssData": {"baseScore": v30}}]
+    if v2 is not None:
+        metrics["cvssMetricV2"] = [{"cvssData": {"baseScore": v2}}]
+    return {
+        "vulnerabilities": [{"cve": {"id": cve_id, "metrics": metrics}}]
+    }
+
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 def _make_enricher(api_key: str = "test-shodan-key", graph_service=None) -> IpToSecurityRisk:
-    """Construct an enricher with a pre-resolved API key and a mocked graph service."""
     mock_vault = Mock()
     mock_vault.get_secret.return_value = api_key
-
     enricher = IpToSecurityRisk(
         sketch_id=str(uuid.uuid4()),
         scan_id="test-scan",
         vault=mock_vault,
         params={},
     )
-
-    # Inject a mock graph service so no real Neo4j connection is needed
     enricher._graph_service = graph_service or MagicMock()
-    # Pre-set params to avoid needing async_init in most tests
     enricher.params = {"SHODAN_API_KEY": api_key}
     return enricher
 
@@ -219,25 +238,27 @@ class TestComputeRiskScore:
         assert score < 50.0
 
     def test_internet_facing_scores_higher_than_internal(self):
-        score_internet = _compute_risk_score(5.0, "internet_facing", "unknown", "inferred")
-        score_internal = _compute_risk_score(5.0, "internal", "unknown", "inferred")
-        assert score_internet > score_internal
+        assert (
+            _compute_risk_score(5.0, "internet_facing", "unknown", "inferred")
+            > _compute_risk_score(5.0, "internal", "unknown", "inferred")
+        )
 
     def test_correlated_evidence_scores_higher_than_inferred(self):
-        score_corr = _compute_risk_score(5.0, "internet_facing", "unknown", "correlated")
-        score_inf = _compute_risk_score(5.0, "internet_facing", "unknown", "inferred")
-        assert score_corr > score_inf
+        assert (
+            _compute_risk_score(5.0, "internet_facing", "unknown", "correlated")
+            > _compute_risk_score(5.0, "internet_facing", "unknown", "inferred")
+        )
 
     def test_public_exploit_scores_higher_than_no_exploit(self):
-        score_exploit = _compute_risk_score(5.0, "internet_facing", "public_exploit", "correlated")
-        score_none = _compute_risk_score(5.0, "internet_facing", "no_exploit", "correlated")
-        assert score_exploit > score_none
+        assert (
+            _compute_risk_score(5.0, "internet_facing", "public_exploit", "correlated")
+            > _compute_risk_score(5.0, "internet_facing", "no_exploit", "correlated")
+        )
 
     def test_formula_matches_manual_calculation(self):
-        # CVSS=8.0, internet_facing(100), public_exploit(65), correlated(0.95)
-        cvss_norm = (8.0 / 10.0) * 100.0  # 80
+        cvss_norm = (8.0 / 10.0) * 100.0
         base = (
-            80.0 * _CVSS_W
+            cvss_norm * _CVSS_W
             + 100.0 * _EXPOSURE_W
             + _SENSITIVITY_UNKNOWN * _SENSITIVITY_W
             + 65.0 * _EXPLOIT_W
@@ -246,8 +267,6 @@ class TestComputeRiskScore:
         assert _compute_risk_score(8.0, "internet_facing", "public_exploit", "correlated") == expected
 
     def test_unknown_exposure_uses_50(self):
-        score = _compute_risk_score(5.0, "unknown", "unknown", "unknown")
-        # Must use EXPOSURE_SCORES["unknown"] = 50
         cvss_norm = 50.0
         base = (
             cvss_norm * _CVSS_W
@@ -256,11 +275,258 @@ class TestComputeRiskScore:
             + 30.0 * _EXPLOIT_W
         )
         expected = round(base * _EVIDENCE_MULTIPLIERS["unknown"], 2)
-        assert score == expected
+        assert _compute_risk_score(5.0, "unknown", "unknown", "unknown") == expected
 
 
 # ---------------------------------------------------------------------------
-# 2. _build_risk_profile — Shodan response parsing
+# 2. _fetch_nvd_cvss — NVD API v2 single-CVE lookup
+# ---------------------------------------------------------------------------
+
+
+class TestFetchNvdCvss:
+    def _mock_response(self, json_data: dict, status: int = 200) -> Mock:
+        resp = Mock()
+        resp.status_code = status
+        resp.json.return_value = json_data
+        resp.raise_for_status = Mock()
+        if status >= 400:
+            http_err = requests_lib.HTTPError(response=resp)
+            resp.raise_for_status.side_effect = http_err
+        return resp
+
+    def test_returns_cvssv31_score(self):
+        with patch("flowsint_enrichers.ip.to_security_risk.requests.get") as mock_get:
+            mock_get.return_value = self._mock_response(
+                _nvd_response("CVE-2021-44228", v31=10.0)
+            )
+            score = _fetch_nvd_cvss("CVE-2021-44228")
+        assert score == 10.0
+
+    def test_cvssv30_used_when_v31_missing(self):
+        with patch("flowsint_enrichers.ip.to_security_risk.requests.get") as mock_get:
+            mock_get.return_value = self._mock_response(
+                _nvd_response("CVE-2020-0001", v30=7.5)
+            )
+            score = _fetch_nvd_cvss("CVE-2020-0001")
+        assert score == 7.5
+
+    def test_cvssv2_used_as_last_resort(self):
+        with patch("flowsint_enrichers.ip.to_security_risk.requests.get") as mock_get:
+            mock_get.return_value = self._mock_response(
+                _nvd_response("CVE-2010-0001", v2=5.0)
+            )
+            score = _fetch_nvd_cvss("CVE-2010-0001")
+        assert score == 5.0
+
+    def test_v31_takes_priority_over_v30(self):
+        with patch("flowsint_enrichers.ip.to_security_risk.requests.get") as mock_get:
+            mock_get.return_value = self._mock_response(
+                _nvd_response("CVE-2021-00001", v31=9.8, v30=7.5)
+            )
+            score = _fetch_nvd_cvss("CVE-2021-00001")
+        assert score == 9.8
+
+    def test_returns_none_for_404(self):
+        with patch("flowsint_enrichers.ip.to_security_risk.requests.get") as mock_get:
+            resp = Mock()
+            resp.status_code = 404
+            resp.raise_for_status = Mock()
+            mock_get.return_value = resp
+            score = _fetch_nvd_cvss("CVE-9999-99999")
+        assert score is None
+
+    def test_returns_none_when_no_vulnerabilities_in_response(self):
+        with patch("flowsint_enrichers.ip.to_security_risk.requests.get") as mock_get:
+            mock_get.return_value = self._mock_response({"vulnerabilities": []})
+            score = _fetch_nvd_cvss("CVE-2021-44228")
+        assert score is None
+
+    def test_returns_none_when_metrics_empty(self):
+        with patch("flowsint_enrichers.ip.to_security_risk.requests.get") as mock_get:
+            mock_get.return_value = self._mock_response(
+                {"vulnerabilities": [{"cve": {"id": "CVE-2021-44228", "metrics": {}}}]}
+            )
+            score = _fetch_nvd_cvss("CVE-2021-44228")
+        assert score is None
+
+    def test_api_key_sent_in_header(self):
+        with patch("flowsint_enrichers.ip.to_security_risk.requests.get") as mock_get:
+            mock_get.return_value = self._mock_response(
+                _nvd_response("CVE-2021-44228", v31=10.0)
+            )
+            _fetch_nvd_cvss("CVE-2021-44228", api_key="my-nvd-key")
+        _, kwargs = mock_get.call_args
+        assert kwargs.get("headers", {}).get("apiKey") == "my-nvd-key"
+
+    def test_no_auth_header_when_key_is_none(self):
+        with patch("flowsint_enrichers.ip.to_security_risk.requests.get") as mock_get:
+            mock_get.return_value = self._mock_response(
+                _nvd_response("CVE-2021-44228", v31=10.0)
+            )
+            _fetch_nvd_cvss("CVE-2021-44228", api_key=None)
+        _, kwargs = mock_get.call_args
+        assert "apiKey" not in kwargs.get("headers", {})
+
+    def test_cve_id_sent_as_query_param(self):
+        with patch("flowsint_enrichers.ip.to_security_risk.requests.get") as mock_get:
+            mock_get.return_value = self._mock_response(
+                _nvd_response("CVE-2021-44228", v31=10.0)
+            )
+            _fetch_nvd_cvss("CVE-2021-44228")
+        _, kwargs = mock_get.call_args
+        assert kwargs.get("params", {}).get("cveId") == "CVE-2021-44228"
+
+    def test_returns_none_on_network_exception(self):
+        with patch("flowsint_enrichers.ip.to_security_risk.requests.get") as mock_get:
+            mock_get.side_effect = ConnectionError("Network down")
+            score = _fetch_nvd_cvss("CVE-2021-44228")
+        assert score is None
+
+    def test_retries_once_on_429_and_returns_score(self):
+        resp_429 = Mock()
+        resp_429.status_code = 429
+        http_err = requests_lib.HTTPError(response=resp_429)
+        resp_429.raise_for_status.side_effect = http_err
+
+        resp_ok = Mock()
+        resp_ok.status_code = 200
+        resp_ok.raise_for_status = Mock()
+        resp_ok.json.return_value = _nvd_response("CVE-2021-44228", v31=10.0)
+
+        with patch("flowsint_enrichers.ip.to_security_risk.requests.get") as mock_get, \
+             patch("flowsint_enrichers.ip.to_security_risk.time.sleep"):
+            mock_get.side_effect = [resp_429, resp_ok]
+            score = _fetch_nvd_cvss("CVE-2021-44228")
+
+        assert score == 10.0
+        assert mock_get.call_count == 2
+
+    def test_returns_none_when_retry_after_429_also_fails(self):
+        resp_429 = Mock()
+        resp_429.status_code = 429
+        http_err = requests_lib.HTTPError(response=resp_429)
+        resp_429.raise_for_status.side_effect = http_err
+
+        with patch("flowsint_enrichers.ip.to_security_risk.requests.get") as mock_get, \
+             patch("flowsint_enrichers.ip.to_security_risk.time.sleep"):
+            mock_get.side_effect = [resp_429, ConnectionError("still down")]
+            score = _fetch_nvd_cvss("CVE-2021-44228")
+
+        assert score is None
+
+
+# ---------------------------------------------------------------------------
+# 3. _resolve_cvss_scores — per-CVE resolution logic
+# ---------------------------------------------------------------------------
+
+
+class TestResolveCvssScores:
+    def test_uses_shodan_score_when_nonzero(self):
+        raw_vulns = {"CVE-2021-44228": {"cvss": 10.0}, "CVE-2021-45046": {"cvss": 9.0}}
+        with patch("flowsint_enrichers.ip.to_security_risk._fetch_nvd_cvss") as mock_nvd, \
+             patch("flowsint_enrichers.ip.to_security_risk.time.sleep"):
+            cvss_map, max_cvss = _resolve_cvss_scores(raw_vulns)
+        mock_nvd.assert_not_called()
+        assert cvss_map == {"CVE-2021-44228": 10.0, "CVE-2021-45046": 9.0}
+        assert max_cvss == 10.0
+
+    def test_calls_nvd_when_shodan_score_is_zero(self):
+        raw_vulns = {"CVE-2023-00001": {"cvss": 0.0}}
+        with patch("flowsint_enrichers.ip.to_security_risk._fetch_nvd_cvss") as mock_nvd, \
+             patch("flowsint_enrichers.ip.to_security_risk.time.sleep"):
+            mock_nvd.return_value = 7.5
+            cvss_map, max_cvss = _resolve_cvss_scores(raw_vulns)
+        mock_nvd.assert_called_once_with("CVE-2023-00001", None)
+        assert cvss_map["CVE-2023-00001"] == 7.5
+        assert max_cvss == 7.5
+
+    def test_calls_nvd_when_shodan_score_is_null(self):
+        raw_vulns = {"CVE-2023-00002": {"cvss": None}}
+        with patch("flowsint_enrichers.ip.to_security_risk._fetch_nvd_cvss") as mock_nvd, \
+             patch("flowsint_enrichers.ip.to_security_risk.time.sleep"):
+            mock_nvd.return_value = 8.1
+            cvss_map, _ = _resolve_cvss_scores(raw_vulns)
+        assert cvss_map["CVE-2023-00002"] == 8.1
+
+    def test_calls_nvd_when_shodan_score_missing(self):
+        raw_vulns = {"CVE-2023-00003": {}}  # no "cvss" key at all
+        with patch("flowsint_enrichers.ip.to_security_risk._fetch_nvd_cvss") as mock_nvd, \
+             patch("flowsint_enrichers.ip.to_security_risk.time.sleep"):
+            mock_nvd.return_value = 5.3
+            cvss_map, _ = _resolve_cvss_scores(raw_vulns)
+        assert cvss_map["CVE-2023-00003"] == 5.3
+
+    def test_fallback_to_6_5_when_both_shodan_and_nvd_fail(self):
+        raw_vulns = {"CVE-2023-00001": {"cvss": 0.0}}
+        with patch("flowsint_enrichers.ip.to_security_risk._fetch_nvd_cvss") as mock_nvd, \
+             patch("flowsint_enrichers.ip.to_security_risk.time.sleep"):
+            mock_nvd.return_value = None  # NVD also has no data
+            cvss_map, max_cvss = _resolve_cvss_scores(raw_vulns)
+        assert cvss_map["CVE-2023-00001"] == _NVD_FALLBACK_CVSS
+        assert max_cvss == _NVD_FALLBACK_CVSS
+
+    def test_mixed_sources_in_same_call(self):
+        # One CVE has a Shodan score; the other needs NVD
+        raw_vulns = {
+            "CVE-2021-44228": {"cvss": 10.0},   # Shodan has it
+            "CVE-2023-00001": {"cvss": 0.0},     # Shodan missing → NVD
+        }
+        with patch("flowsint_enrichers.ip.to_security_risk._fetch_nvd_cvss") as mock_nvd, \
+             patch("flowsint_enrichers.ip.to_security_risk.time.sleep"):
+            mock_nvd.return_value = 7.5
+            cvss_map, max_cvss = _resolve_cvss_scores(raw_vulns)
+        mock_nvd.assert_called_once_with("CVE-2023-00001", None)
+        assert cvss_map["CVE-2021-44228"] == 10.0
+        assert cvss_map["CVE-2023-00001"] == 7.5
+        assert max_cvss == 10.0
+
+    def test_empty_vulns_returns_empty_map_and_zero(self):
+        cvss_map, max_cvss = _resolve_cvss_scores({})
+        assert cvss_map == {}
+        assert max_cvss == 0.0
+
+    def test_nvd_api_key_forwarded_to_fetch(self):
+        raw_vulns = {"CVE-2023-00001": {"cvss": 0.0}}
+        with patch("flowsint_enrichers.ip.to_security_risk._fetch_nvd_cvss") as mock_nvd, \
+             patch("flowsint_enrichers.ip.to_security_risk.time.sleep"):
+            mock_nvd.return_value = 7.5
+            _resolve_cvss_scores(raw_vulns, nvd_api_key="my-nvd-key")
+        mock_nvd.assert_called_once_with("CVE-2023-00001", "my-nvd-key")
+
+    def test_delay_called_for_each_nvd_lookup(self):
+        raw_vulns = {
+            "CVE-2023-00001": {"cvss": 0.0},
+            "CVE-2023-00002": {"cvss": 0.0},
+        }
+        with patch("flowsint_enrichers.ip.to_security_risk._fetch_nvd_cvss") as mock_nvd, \
+             patch("flowsint_enrichers.ip.to_security_risk.time.sleep") as mock_sleep:
+            mock_nvd.return_value = 5.0
+            _resolve_cvss_scores(raw_vulns)
+        assert mock_sleep.call_count == 2
+
+    def test_no_delay_when_all_scores_from_shodan(self):
+        raw_vulns = {
+            "CVE-2021-44228": {"cvss": 10.0},
+            "CVE-2021-45046": {"cvss": 9.0},
+        }
+        with patch("flowsint_enrichers.ip.to_security_risk.time.sleep") as mock_sleep:
+            _resolve_cvss_scores(raw_vulns)
+        mock_sleep.assert_not_called()
+
+    def test_max_cvss_reflects_highest_resolved_score(self):
+        raw_vulns = {
+            "CVE-A": {"cvss": 4.0},
+            "CVE-B": {"cvss": 0.0},
+        }
+        with patch("flowsint_enrichers.ip.to_security_risk._fetch_nvd_cvss") as mock_nvd, \
+             patch("flowsint_enrichers.ip.to_security_risk.time.sleep"):
+            mock_nvd.return_value = 9.8
+            _, max_cvss = _resolve_cvss_scores(raw_vulns)
+        assert max_cvss == 9.8
+
+
+# ---------------------------------------------------------------------------
+# 4. _build_risk_profile — Shodan response parsing with real CVSS scores
 # ---------------------------------------------------------------------------
 
 
@@ -268,216 +534,196 @@ class TestBuildRiskProfile:
     def setup_method(self):
         self.enricher = _make_enricher()
 
-    def _build(self, address: str, host: Dict[str, Any]) -> RiskProfile:
-        return self.enricher._build_risk_profile(address, host)
+    def _build(
+        self,
+        address: str,
+        host: Dict[str, Any],
+        cvss_per_cve: Dict[str, float],
+        max_cvss: float,
+    ) -> RiskProfile:
+        return self.enricher._build_risk_profile(address, host, cvss_per_cve, max_cvss)
 
     # --- RiskProfile fields --------------------------------------------------
 
     def test_entity_id_matches_address(self):
-        profile = self._build("1.2.3.4", SHODAN_RICH)
-        assert profile.entity_id == "1.2.3.4"
+        p = self._build("1.2.3.4", SHODAN_RICH, CVSS_RICH_MAP, CVSS_RICH_MAX)
+        assert p.entity_id == "1.2.3.4"
 
     def test_entity_type_is_ip(self):
-        profile = self._build("1.2.3.4", SHODAN_RICH)
-        assert profile.entity_type == "IP"
+        p = self._build("1.2.3.4", SHODAN_RICH, CVSS_RICH_MAP, CVSS_RICH_MAX)
+        assert p.entity_type == "IP"
 
     def test_source_is_shodan(self):
-        profile = self._build("1.2.3.4", SHODAN_RICH)
-        assert profile.source == "Shodan"
+        p = self._build("1.2.3.4", SHODAN_RICH, CVSS_RICH_MAP, CVSS_RICH_MAX)
+        assert p.source == "Shodan"
 
     def test_assessment_date_is_set(self):
-        profile = self._build("1.2.3.4", SHODAN_RICH)
-        assert profile.assessment_date is not None
-        assert "Z" in profile.assessment_date
+        p = self._build("1.2.3.4", SHODAN_RICH, CVSS_RICH_MAP, CVSS_RICH_MAX)
+        assert p.assessment_date and "Z" in p.assessment_date
 
-    def test_risk_level_is_valid_string(self):
-        profile = self._build("1.2.3.4", SHODAN_RICH)
-        assert profile.risk_level in ("low", "medium", "high", "critical")
+    def test_risk_level_is_valid(self):
+        p = self._build("1.2.3.4", SHODAN_RICH, CVSS_RICH_MAP, CVSS_RICH_MAX)
+        assert p.risk_level in ("low", "medium", "high", "critical")
 
     def test_overall_risk_score_in_range(self):
-        profile = self._build("1.2.3.4", SHODAN_RICH)
-        assert 0.0 <= profile.overall_risk_score <= 100.0
+        p = self._build("1.2.3.4", SHODAN_RICH, CVSS_RICH_MAP, CVSS_RICH_MAX)
+        assert 0.0 <= p.overall_risk_score <= 100.0
 
     # --- CVE handling --------------------------------------------------------
 
-    def test_cves_extracted_from_rich_response(self):
-        profile = self._build("1.2.3.4", SHODAN_RICH)
-        assert profile.vulnerabilities is not None
-        assert "CVE-2021-44228" in profile.vulnerabilities
-        assert "CVE-2021-45046" in profile.vulnerabilities
+    def test_cves_extracted_from_cvss_map(self):
+        p = self._build("1.2.3.4", SHODAN_RICH, CVSS_RICH_MAP, CVSS_RICH_MAX)
+        assert "CVE-2021-44228" in p.vulnerabilities
+        assert "CVE-2021-45046" in p.vulnerabilities
 
-    def test_no_cves_when_vulns_empty(self):
-        profile = self._build("5.6.7.8", SHODAN_NO_CVES)
-        assert not profile.vulnerabilities
-
-    def test_cvss_floor_applied_when_cves_present_but_cvss_zero(self):
-        # CVE exists with CVSS=0 → must be floored to 6.5 before scoring
-        profile_floored = self._build("3.4.5.6", SHODAN_CVSS_ZERO)
-        # Compute what score WOULD be with CVSS=6.5 (floor)
-        expected_score = _compute_risk_score(6.5, "internet_facing", "public_exploit", "correlated")
-        assert profile_floored.overall_risk_score == expected_score
+    def test_no_cves_when_cvss_map_empty(self):
+        p = self._build("5.6.7.8", SHODAN_NO_CVES, {}, 0.0)
+        assert not p.vulnerabilities
 
     def test_high_cvss_produces_higher_score_than_low(self):
-        profile_high = self._build("1.2.3.4", SHODAN_RICH)   # CVSS 10.0
-        profile_low = self._build("5.6.7.8", SHODAN_NO_CVES)  # no CVEs → CVSS 0
-        assert profile_high.overall_risk_score > profile_low.overall_risk_score
+        p_high = self._build("1.2.3.4", SHODAN_RICH, CVSS_RICH_MAP, CVSS_RICH_MAX)
+        p_low = self._build("5.6.7.8", SHODAN_NO_CVES, {}, 0.0)
+        assert p_high.overall_risk_score > p_low.overall_risk_score
+
+    def test_nvd_resolved_score_used_correctly(self):
+        # When NVD returned 7.5 for a CVE, the score must use 7.5, not 6.5
+        nvd_map = {"CVE-2023-00001": 7.5}
+        p = self._build("3.4.5.6", SHODAN_CVSS_ZERO, nvd_map, 7.5)
+        expected = _compute_risk_score(7.5, "internet_facing", "public_exploit", "correlated")
+        assert p.overall_risk_score == expected
+
+    def test_fallback_score_used_when_nvd_also_failed(self):
+        # When both Shodan and NVD failed, the fallback 6.5 must drive the score
+        fallback_map = {"CVE-2023-00001": _NVD_FALLBACK_CVSS}
+        p = self._build("3.4.5.6", SHODAN_CVSS_ZERO, fallback_map, _NVD_FALLBACK_CVSS)
+        expected = _compute_risk_score(_NVD_FALLBACK_CVSS, "internet_facing", "public_exploit", "correlated")
+        assert p.overall_risk_score == expected
+
+    # --- Scoring formula correctness -----------------------------------------
+
+    def test_exploit_status_public_when_cves_present(self):
+        p = self._build("1.2.3.4", SHODAN_RICH, CVSS_RICH_MAP, CVSS_RICH_MAX)
+        expected = _compute_risk_score(10.0, "internet_facing", "public_exploit", "correlated")
+        assert p.overall_risk_score == expected
+
+    def test_exploit_status_unknown_when_no_cves(self):
+        p = self._build("5.6.7.8", SHODAN_NO_CVES, {}, 0.0)
+        expected = _compute_risk_score(0.0, "internet_facing", "unknown", "inferred")
+        assert p.overall_risk_score == expected
+
+    def test_minimal_host_uses_unknown_evidence(self):
+        p = self._build("9.9.9.9", SHODAN_MINIMAL, {}, 0.0)
+        expected = _compute_risk_score(0.0, "unknown", "unknown", "unknown")
+        assert p.overall_risk_score == expected
 
     # --- Exposure detection --------------------------------------------------
 
     def test_internet_facing_via_service_name(self):
-        # SHODAN_RICH has ssh/http/https/mysql modules → internet_facing
-        profile = self._build("1.2.3.4", SHODAN_RICH)
-        assert profile.exposure_surface is not None
-        # risk_factors should mention internet-facing
-        assert profile.risk_factors is not None
-        assert any("internet" in f.lower() for f in profile.risk_factors)
+        p = self._build("1.2.3.4", SHODAN_RICH, CVSS_RICH_MAP, CVSS_RICH_MAX)
+        assert any("internet" in f.lower() for f in (p.risk_factors or []))
 
     def test_internet_facing_via_well_known_port_number(self):
-        # Port 443 is in the known-ports set even if module name not recognised
         host = {
-            "ip_str": "1.2.3.4",
-            "ports": [443],
+            "ip_str": "1.2.3.4", "ports": [443],
             "data": [{"port": 443, "transport": "tcp", "_shodan": {"module": ""}, "data": ""}],
             "vulns": {},
         }
-        profile = self._build("1.2.3.4", host)
-        assert any("internet" in f.lower() for f in (profile.risk_factors or []))
+        p = self._build("1.2.3.4", host, {}, 0.0)
+        assert any("internet" in f.lower() for f in (p.risk_factors or []))
 
-    def test_non_internet_facing_port_classified_unknown(self):
-        # Only port 12345 open, no service name, no known-port match
-        profile = self._build("9.9.9.9", SHODAN_MINIMAL)
-        # No internet-facing risk factor expected
-        internet_factors = [f for f in (profile.risk_factors or []) if "internet" in f.lower()]
-        assert len(internet_factors) == 0
-
-    # --- Exploit status and evidence -----------------------------------------
-
-    def test_exploit_status_public_when_cves_present(self):
-        # When CVEs exist, exploit_status → public_exploit, evidence → correlated
-        # Risk score should use public_exploit (65) and correlated (0.95)
-        profile = self._build("1.2.3.4", SHODAN_RICH)
-        expected = _compute_risk_score(10.0, "internet_facing", "public_exploit", "correlated")
-        assert profile.overall_risk_score == expected
-
-    def test_exploit_status_unknown_when_no_cves(self):
-        # No CVEs, internet-facing → unknown exploit, inferred evidence
-        profile = self._build("5.6.7.8", SHODAN_NO_CVES)
-        expected = _compute_risk_score(0.0, "internet_facing", "unknown", "inferred")
-        assert profile.overall_risk_score == expected
-
-    def test_minimal_host_uses_unknown_evidence(self):
-        # No data[], no vulns → unknown evidence
-        profile = self._build("9.9.9.9", SHODAN_MINIMAL)
-        expected = _compute_risk_score(0.0, "unknown", "unknown", "unknown")
-        assert profile.overall_risk_score == expected
+    def test_non_internet_facing_port_no_internet_factor(self):
+        p = self._build("9.9.9.9", SHODAN_MINIMAL, {}, 0.0)
+        assert not any("internet" in f.lower() for f in (p.risk_factors or []))
 
     # --- Risk factors ---------------------------------------------------------
 
+    def test_risk_factors_show_real_per_cve_scores(self):
+        p = self._build("1.2.3.4", SHODAN_RICH, CVSS_RICH_MAP, CVSS_RICH_MAX)
+        cve_factor = next((f for f in (p.risk_factors or []) if "CVE" in f), None)
+        assert cve_factor is not None
+        assert "10.0" in cve_factor
+        assert "9.0" in cve_factor
+
     def test_rdp_exposure_adds_risk_factor(self):
-        profile = self._build("2.3.4.5", SHODAN_RDP_EXPOSED)
-        assert profile.risk_factors is not None
-        assert any("RDP" in f for f in profile.risk_factors)
+        p = self._build("2.3.4.5", SHODAN_RDP_EXPOSED, {}, 0.0)
+        assert any("RDP" in f for f in (p.risk_factors or []))
 
     def test_ssh_exposure_adds_risk_factor(self):
-        profile = self._build("1.2.3.4", SHODAN_RICH)
-        assert profile.risk_factors is not None
-        assert any("SSH" in f for f in profile.risk_factors)
+        p = self._build("1.2.3.4", SHODAN_RICH, CVSS_RICH_MAP, CVSS_RICH_MAX)
+        assert any("SSH" in f for f in (p.risk_factors or []))
 
     def test_database_exposure_adds_risk_factor(self):
-        profile = self._build("1.2.3.4", SHODAN_RICH)  # has port 3306
-        assert profile.risk_factors is not None
-        assert any("Database" in f or "database" in f for f in profile.risk_factors)
+        p = self._build("1.2.3.4", SHODAN_RICH, CVSS_RICH_MAP, CVSS_RICH_MAX)
+        assert any("Database" in f or "database" in f for f in (p.risk_factors or []))
 
     def test_critical_cvss_adds_risk_factor(self):
-        profile = self._build("1.2.3.4", SHODAN_RICH)  # CVSS 10.0
-        assert any("Critical" in f or "CVSS ≥ 9" in f for f in (profile.risk_factors or []))
+        p = self._build("1.2.3.4", SHODAN_RICH, CVSS_RICH_MAP, CVSS_RICH_MAX)
+        assert any("CVSS ≥ 9" in f for f in (p.risk_factors or []))
 
     # --- Compliance risks -----------------------------------------------------
 
     def test_pci_compliance_risk_when_high_cvss_cves(self):
-        profile = self._build("1.2.3.4", SHODAN_RICH)
-        assert profile.compliance_risks is not None
-        assert any("PCI" in r for r in profile.compliance_risks)
+        p = self._build("1.2.3.4", SHODAN_RICH, CVSS_RICH_MAP, CVSS_RICH_MAX)
+        assert any("PCI" in r for r in (p.compliance_risks or []))
 
     def test_gdpr_compliance_risk_when_database_exposed(self):
-        profile = self._build("1.2.3.4", SHODAN_RICH)  # port 3306
-        assert profile.compliance_risks is not None
-        assert any("GDPR" in r for r in profile.compliance_risks)
+        p = self._build("1.2.3.4", SHODAN_RICH, CVSS_RICH_MAP, CVSS_RICH_MAX)
+        assert any("GDPR" in r for r in (p.compliance_risks or []))
 
     def test_no_compliance_risks_for_minimal_host(self):
-        profile = self._build("9.9.9.9", SHODAN_MINIMAL)
-        # No CVEs above CVSS 7.0, no DB ports → empty compliance_risks
-        assert not profile.compliance_risks
+        p = self._build("9.9.9.9", SHODAN_MINIMAL, {}, 0.0)
+        assert not p.compliance_risks
 
     # --- Mitigations ----------------------------------------------------------
 
     def test_mitigations_non_empty_for_rich_host(self):
-        profile = self._build("1.2.3.4", SHODAN_RICH)
-        assert profile.mitigation_strategies
-        assert len(profile.mitigation_strategies) > 0
+        p = self._build("1.2.3.4", SHODAN_RICH, CVSS_RICH_MAP, CVSS_RICH_MAX)
+        assert p.mitigation_strategies and len(p.mitigation_strategies) > 0
 
     def test_rdp_mitigation_recommended(self):
-        profile = self._build("2.3.4.5", SHODAN_RDP_EXPOSED)
-        assert profile.mitigation_strategies is not None
-        assert any("RDP" in m for m in profile.mitigation_strategies)
+        p = self._build("2.3.4.5", SHODAN_RDP_EXPOSED, {}, 0.0)
+        assert any("RDP" in m for m in (p.mitigation_strategies or []))
 
     def test_cve_patch_recommendation_included(self):
-        profile = self._build("1.2.3.4", SHODAN_RICH)
-        assert profile.mitigation_strategies is not None
-        assert any("CVE" in m for m in profile.mitigation_strategies)
+        p = self._build("1.2.3.4", SHODAN_RICH, CVSS_RICH_MAP, CVSS_RICH_MAX)
+        assert any("CVE" in m for m in (p.mitigation_strategies or []))
 
     # --- Exposure surface metadata -------------------------------------------
 
     def test_org_in_exposure_surface(self):
-        profile = self._build("1.2.3.4", SHODAN_RICH)
-        assert profile.exposure_surface is not None
-        assert "Acme Corp" in profile.exposure_surface
+        p = self._build("1.2.3.4", SHODAN_RICH, CVSS_RICH_MAP, CVSS_RICH_MAX)
+        assert "Acme Corp" in (p.exposure_surface or "")
 
     def test_asn_in_exposure_surface(self):
-        profile = self._build("1.2.3.4", SHODAN_RICH)
-        assert "AS12345" in profile.exposure_surface
+        p = self._build("1.2.3.4", SHODAN_RICH, CVSS_RICH_MAP, CVSS_RICH_MAX)
+        assert "AS12345" in (p.exposure_surface or "")
 
-    def test_country_in_exposure_surface(self):
-        profile = self._build("1.2.3.4", SHODAN_RICH)
-        assert "United States" in profile.exposure_surface
-
-    def test_open_ports_listed_in_exposure_surface(self):
-        profile = self._build("1.2.3.4", SHODAN_RICH)
-        assert "22" in profile.exposure_surface
-        assert "443" in profile.exposure_surface
+    def test_open_ports_in_exposure_surface(self):
+        p = self._build("1.2.3.4", SHODAN_RICH, CVSS_RICH_MAP, CVSS_RICH_MAX)
+        assert "22" in (p.exposure_surface or "") and "443" in (p.exposure_surface or "")
 
     # --- Temp attribute for postprocess ---------------------------------------
 
     def test_shodan_ports_stored_as_temp_attribute(self):
-        profile = self._build("1.2.3.4", SHODAN_RICH)
-        ports = getattr(profile, "_shodan_ports", None)
-        assert ports is not None
-        assert len(ports) == 4  # 22, 80, 443, 3306
-        numbers = {p["number"] for p in ports}
-        assert numbers == {22, 80, 443, 3306}
-
-    def test_port_service_names_captured(self):
-        profile = self._build("1.2.3.4", SHODAN_RICH)
-        ports = getattr(profile, "_shodan_ports", [])
-        port_22 = next(p for p in ports if p["number"] == 22)
-        assert port_22["service"] == "ssh"
+        p = self._build("1.2.3.4", SHODAN_RICH, CVSS_RICH_MAP, CVSS_RICH_MAX)
+        ports = getattr(p, "_shodan_ports", None)
+        assert ports is not None and len(ports) == 4
 
     def test_fallback_to_ports_list_when_no_banner_data(self):
-        profile = self._build("9.9.9.9", SHODAN_MINIMAL)  # data=[], ports=[12345]
-        ports = getattr(profile, "_shodan_ports", [])
-        assert len(ports) == 1
-        assert ports[0]["number"] == 12345
+        p = self._build("9.9.9.9", SHODAN_MINIMAL, {}, 0.0)
+        ports = getattr(p, "_shodan_ports", [])
+        assert len(ports) == 1 and ports[0]["number"] == 12345
 
     # --- Confidence -----------------------------------------------------------
 
     def test_confidence_higher_when_cves_present(self):
-        profile_with_cves = self._build("1.2.3.4", SHODAN_RICH)
-        profile_without_cves = self._build("5.6.7.8", SHODAN_NO_CVES)
-        assert profile_with_cves.confidence > profile_without_cves.confidence
+        p_cves = self._build("1.2.3.4", SHODAN_RICH, CVSS_RICH_MAP, CVSS_RICH_MAX)
+        p_none = self._build("5.6.7.8", SHODAN_NO_CVES, {}, 0.0)
+        assert p_cves.confidence > p_none.confidence
 
 
 # ---------------------------------------------------------------------------
-# 3. scan() — async, mocked Shodan API
+# 5. scan() — async, mocked Shodan + _resolve_cvss_scores
 # ---------------------------------------------------------------------------
 
 
@@ -485,9 +731,24 @@ class TestScan:
     def setup_method(self):
         self.enricher = _make_enricher()
 
+    def _patch_scan(self, host_return=None, host_side_effect=None):
+        """Context manager that patches both Shodan and _resolve_cvss_scores."""
+        mock_api = MagicMock()
+        if host_side_effect:
+            mock_api.host.side_effect = host_side_effect
+        else:
+            mock_api.host.return_value = host_return
+
+        shodan_patch = patch("flowsint_enrichers.ip.to_security_risk.shodan")
+        resolve_patch = patch(
+            "flowsint_enrichers.ip.to_security_risk._resolve_cvss_scores",
+            return_value=(CVSS_RICH_MAP, CVSS_RICH_MAX),
+        )
+        return shodan_patch, resolve_patch, mock_api
+
     @pytest.mark.asyncio
     async def test_returns_empty_list_when_api_key_missing(self):
-        self.enricher.params = {}  # no SHODAN_API_KEY
+        self.enricher.params = {}
         results = await self.enricher.scan([Ip(address="1.2.3.4")])
         assert results == []
 
@@ -499,15 +760,11 @@ class TestScan:
 
     @pytest.mark.asyncio
     async def test_happy_path_returns_one_profile_per_ip(self):
-        mock_api = MagicMock()
-        mock_api.host.return_value = SHODAN_RICH
-
-        with patch("flowsint_enrichers.ip.to_security_risk.shodan") as mock_shodan_mod:
-            mock_shodan_mod.Shodan.return_value = mock_api
-            mock_shodan_mod.APIError = Exception
-
+        sp, rp, mock_api = self._patch_scan(host_return=SHODAN_RICH)
+        with sp as ms, rp:
+            ms.Shodan.return_value = mock_api
+            ms.APIError = Exception
             results = await self.enricher.scan([Ip(address="1.2.3.4")])
-
         assert len(results) == 1
         assert isinstance(results[0], RiskProfile)
         assert results[0].entity_id == "1.2.3.4"
@@ -516,101 +773,103 @@ class TestScan:
     async def test_multiple_ips_each_get_a_profile(self):
         mock_api = MagicMock()
         mock_api.host.side_effect = [SHODAN_RICH, SHODAN_NO_CVES]
-
-        with patch("flowsint_enrichers.ip.to_security_risk.shodan") as mock_shodan_mod:
-            mock_shodan_mod.Shodan.return_value = mock_api
-            mock_shodan_mod.APIError = Exception
-
-            results = await self.enricher.scan([
-                Ip(address="1.2.3.4"),
-                Ip(address="5.6.7.8"),
-            ])
-
+        with patch("flowsint_enrichers.ip.to_security_risk.shodan") as ms, \
+             patch("flowsint_enrichers.ip.to_security_risk._resolve_cvss_scores",
+                   side_effect=[(CVSS_RICH_MAP, CVSS_RICH_MAX), ({}, 0.0)]):
+            ms.Shodan.return_value = mock_api
+            ms.APIError = Exception
+            results = await self.enricher.scan([Ip(address="1.2.3.4"), Ip(address="5.6.7.8")])
         assert len(results) == 2
         assert results[0].entity_id == "1.2.3.4"
         assert results[1].entity_id == "5.6.7.8"
 
     @pytest.mark.asyncio
     async def test_shodan_api_error_skips_ip_gracefully(self):
-        class FakeShodanAPIError(Exception):
+        class FakeAPIError(Exception):
             pass
 
         mock_api = MagicMock()
-        mock_api.host.side_effect = FakeShodanAPIError("No information available")
-
-        with patch("flowsint_enrichers.ip.to_security_risk.shodan") as mock_shodan_mod:
-            mock_shodan_mod.Shodan.return_value = mock_api
-            mock_shodan_mod.APIError = FakeShodanAPIError
-
+        mock_api.host.side_effect = FakeAPIError("No info")
+        with patch("flowsint_enrichers.ip.to_security_risk.shodan") as ms, \
+             patch("flowsint_enrichers.ip.to_security_risk._resolve_cvss_scores"):
+            ms.Shodan.return_value = mock_api
+            ms.APIError = FakeAPIError
             results = await self.enricher.scan([Ip(address="1.2.3.4")])
-
         assert results == []
 
     @pytest.mark.asyncio
     async def test_generic_exception_skips_ip_gracefully(self):
         mock_api = MagicMock()
-        mock_api.host.side_effect = RuntimeError("connection reset")
-
-        with patch("flowsint_enrichers.ip.to_security_risk.shodan") as mock_shodan_mod:
-            mock_shodan_mod.Shodan.return_value = mock_api
-            mock_shodan_mod.APIError = Exception  # RuntimeError won't match this
-
+        mock_api.host.side_effect = RuntimeError("reset")
+        with patch("flowsint_enrichers.ip.to_security_risk.shodan") as ms, \
+             patch("flowsint_enrichers.ip.to_security_risk._resolve_cvss_scores"):
+            ms.Shodan.return_value = mock_api
+            ms.APIError = Exception
             results = await self.enricher.scan([Ip(address="1.2.3.4")])
-
         assert results == []
 
     @pytest.mark.asyncio
     async def test_one_ip_fails_others_still_processed(self):
-        class FakeShodanAPIError(Exception):
+        class FakeAPIError(Exception):
             pass
 
         mock_api = MagicMock()
-        mock_api.host.side_effect = [
-            FakeShodanAPIError("No info"),  # first IP fails
-            SHODAN_NO_CVES,                  # second IP succeeds
-        ]
-
-        with patch("flowsint_enrichers.ip.to_security_risk.shodan") as mock_shodan_mod:
-            mock_shodan_mod.Shodan.return_value = mock_api
-            mock_shodan_mod.APIError = FakeShodanAPIError
-
-            results = await self.enricher.scan([
-                Ip(address="1.2.3.4"),
-                Ip(address="5.6.7.8"),
-            ])
-
+        mock_api.host.side_effect = [FakeAPIError("no info"), SHODAN_NO_CVES]
+        with patch("flowsint_enrichers.ip.to_security_risk.shodan") as ms, \
+             patch("flowsint_enrichers.ip.to_security_risk._resolve_cvss_scores",
+                   return_value=({}, 0.0)):
+            ms.Shodan.return_value = mock_api
+            ms.APIError = FakeAPIError
+            results = await self.enricher.scan([Ip(address="1.2.3.4"), Ip(address="5.6.7.8")])
         assert len(results) == 1
         assert results[0].entity_id == "5.6.7.8"
 
     @pytest.mark.asyncio
     async def test_shodan_called_with_correct_ip(self):
-        mock_api = MagicMock()
-        mock_api.host.return_value = SHODAN_RICH
-
-        with patch("flowsint_enrichers.ip.to_security_risk.shodan") as mock_shodan_mod:
-            mock_shodan_mod.Shodan.return_value = mock_api
-            mock_shodan_mod.APIError = Exception
-
+        sp, rp, mock_api = self._patch_scan(host_return=SHODAN_RICH)
+        with sp as ms, rp:
+            ms.Shodan.return_value = mock_api
+            ms.APIError = Exception
             await self.enricher.scan([Ip(address="1.2.3.4")])
-
         mock_api.host.assert_called_once_with("1.2.3.4")
 
     @pytest.mark.asyncio
     async def test_shodan_initialised_with_api_key(self):
+        sp, rp, mock_api = self._patch_scan(host_return=SHODAN_RICH)
+        with sp as ms, rp:
+            ms.Shodan.return_value = mock_api
+            ms.APIError = Exception
+            await self.enricher.scan([Ip(address="1.2.3.4")])
+        ms.Shodan.assert_called_once_with("test-shodan-key")
+
+    @pytest.mark.asyncio
+    async def test_resolve_cvss_called_with_vulns_and_nvd_key(self):
+        self.enricher.params["NVD_API_KEY"] = "my-nvd-key"
         mock_api = MagicMock()
         mock_api.host.return_value = SHODAN_RICH
-
-        with patch("flowsint_enrichers.ip.to_security_risk.shodan") as mock_shodan_mod:
-            mock_shodan_mod.Shodan.return_value = mock_api
-            mock_shodan_mod.APIError = Exception
-
+        with patch("flowsint_enrichers.ip.to_security_risk.shodan") as ms, \
+             patch("flowsint_enrichers.ip.to_security_risk._resolve_cvss_scores",
+                   return_value=(CVSS_RICH_MAP, CVSS_RICH_MAX)) as mock_resolve:
+            ms.Shodan.return_value = mock_api
+            ms.APIError = Exception
             await self.enricher.scan([Ip(address="1.2.3.4")])
+        mock_resolve.assert_called_once_with(SHODAN_RICH["vulns"], "my-nvd-key")
 
-        mock_shodan_mod.Shodan.assert_called_once_with("test-shodan-key")
+    @pytest.mark.asyncio
+    async def test_resolve_cvss_called_with_none_when_no_nvd_key(self):
+        mock_api = MagicMock()
+        mock_api.host.return_value = SHODAN_RICH
+        with patch("flowsint_enrichers.ip.to_security_risk.shodan") as ms, \
+             patch("flowsint_enrichers.ip.to_security_risk._resolve_cvss_scores",
+                   return_value=(CVSS_RICH_MAP, CVSS_RICH_MAX)) as mock_resolve:
+            ms.Shodan.return_value = mock_api
+            ms.APIError = Exception
+            await self.enricher.scan([Ip(address="1.2.3.4")])
+        mock_resolve.assert_called_once_with(SHODAN_RICH["vulns"], None)
 
 
 # ---------------------------------------------------------------------------
-# 4. postprocess() — graph node/relationship creation
+# 6. postprocess() — graph node/relationship creation
 # ---------------------------------------------------------------------------
 
 
@@ -619,78 +878,63 @@ class TestPostprocess:
         self.graph = MagicMock()
         self.enricher = _make_enricher(graph_service=self.graph)
 
-    def _profile_with_ports(self, address: str = "1.2.3.4") -> RiskProfile:
-        profile = self.enricher._build_risk_profile(address, SHODAN_RICH)
-        return profile
+    def _profile(self, address: str = "1.2.3.4") -> RiskProfile:
+        return self.enricher._build_risk_profile(
+            address, SHODAN_RICH, CVSS_RICH_MAP, CVSS_RICH_MAX
+        )
 
-    def test_creates_ip_node(self):
-        profile = self._profile_with_ports()
+    def test_creates_ip_and_risk_profile_nodes(self):
+        profile = self._profile()
         self.enricher.postprocess([profile], [Ip(address="1.2.3.4")])
-        calls = [str(c) for c in self.graph.create_node_from_flowsint_type.call_args_list]
-        assert any("1.2.3.4" in c for c in calls)
-
-    def test_creates_risk_profile_node(self):
-        profile = self._profile_with_ports()
-        self.enricher.postprocess([profile], [Ip(address="1.2.3.4")])
-        # At minimum two nodes: IP + RiskProfile
         assert self.graph.create_node_from_flowsint_type.call_count >= 2
 
     def test_creates_has_risk_profile_relationship(self):
-        profile = self._profile_with_ports()
+        profile = self._profile()
         self.enricher.postprocess([profile], [Ip(address="1.2.3.4")])
         rel_labels = [
-            call.args[2] if call.args else call.kwargs.get("rel_label")
-            for call in self.graph.create_relationship.call_args_list
+            c.args[2] if c.args else c.kwargs.get("rel_label")
+            for c in self.graph.create_relationship.call_args_list
         ]
         assert "HAS_RISK_PROFILE" in rel_labels
 
-    def test_creates_has_port_relationships_for_each_port(self):
-        profile = self._profile_with_ports()
+    def test_creates_has_port_for_each_port(self):
+        profile = self._profile()
         self.enricher.postprocess([profile], [Ip(address="1.2.3.4")])
         rel_labels = [
-            call.args[2] if call.args else call.kwargs.get("rel_label")
-            for call in self.graph.create_relationship.call_args_list
+            c.args[2] if c.args else c.kwargs.get("rel_label")
+            for c in self.graph.create_relationship.call_args_list
         ]
-        # SHODAN_RICH has 4 ports → 4 HAS_PORT relationships + 1 HAS_RISK_PROFILE
+        # SHODAN_RICH has 4 ports
         assert rel_labels.count("HAS_PORT") == 4
 
-    def test_temp_attribute_cleaned_up_after_postprocess(self):
-        profile = self._profile_with_ports()
+    def test_temp_attribute_cleaned_up(self):
+        profile = self._profile()
         assert hasattr(profile, "_shodan_ports")
         self.enricher.postprocess([profile], [Ip(address="1.2.3.4")])
         assert not hasattr(profile, "_shodan_ports")
 
     def test_no_crash_when_graph_service_is_none(self):
         self.enricher._graph_service = None
-        profile = self._profile_with_ports()
+        profile = self._profile()
         result = self.enricher.postprocess([profile], [Ip(address="1.2.3.4")])
         assert result == [profile]
 
     def test_returns_results_unchanged(self):
-        profile = self._profile_with_ports()
+        profile = self._profile()
         result = self.enricher.postprocess([profile], [Ip(address="1.2.3.4")])
         assert result == [profile]
 
     def test_handles_empty_results(self):
-        result = self.enricher.postprocess([], [])
-        assert result == []
+        assert self.enricher.postprocess([], []) == []
 
-    def test_flush_called_on_graph_service(self):
-        # The base execute() calls flush(), but postprocess should not need to.
-        # This test just ensures postprocess runs without error when flush IS called.
-        profile = self._profile_with_ports()
-        self.enricher.postprocess([profile], [Ip(address="1.2.3.4")])
-        # No assertion — just checks no exception is raised
-
-    def test_ip_reconstructed_when_not_in_input_data(self):
-        # If input_data is None, IP node should still be created from entity_id
-        profile = self._profile_with_ports()
+    def test_ip_reconstructed_when_input_data_is_none(self):
+        profile = self._profile()
         self.enricher.postprocess([profile], None)
         self.graph.create_node_from_flowsint_type.assert_called()
 
 
 # ---------------------------------------------------------------------------
-# 5. Enricher metadata / registration
+# 7. Enricher metadata / registration
 # ---------------------------------------------------------------------------
 
 
@@ -711,38 +955,40 @@ class TestEnricherMetadata:
         assert OutputType is RiskProfile
 
     def test_input_schema_type(self):
-        schema = IpToSecurityRisk.input_schema()
-        assert schema["type"] == "Ip"
+        assert IpToSecurityRisk.input_schema()["type"] == "Ip"
 
     def test_output_schema_type(self):
-        schema = IpToSecurityRisk.output_schema()
-        assert schema["type"] == "RiskProfile"
+        assert IpToSecurityRisk.output_schema()["type"] == "RiskProfile"
 
     def test_required_params_is_true(self):
         assert IpToSecurityRisk.required_params() is True
 
-    def test_params_schema_declares_shodan_key(self):
-        schema = IpToSecurityRisk.get_params_schema()
-        names = [p["name"] for p in schema]
+    def test_params_schema_has_shodan_key(self):
+        names = [p["name"] for p in IpToSecurityRisk.get_params_schema()]
         assert "SHODAN_API_KEY" in names
 
-    def test_shodan_key_param_is_vault_secret(self):
-        schema = IpToSecurityRisk.get_params_schema()
-        shodan_param = next(p for p in schema if p["name"] == "SHODAN_API_KEY")
-        assert shodan_param["type"] == "vaultSecret"
+    def test_shodan_key_is_required_vault_secret(self):
+        param = next(p for p in IpToSecurityRisk.get_params_schema() if p["name"] == "SHODAN_API_KEY")
+        assert param["type"] == "vaultSecret"
+        assert param["required"] is True
 
-    def test_shodan_key_param_is_required(self):
-        schema = IpToSecurityRisk.get_params_schema()
-        shodan_param = next(p for p in schema if p["name"] == "SHODAN_API_KEY")
-        assert shodan_param["required"] is True
+    def test_params_schema_has_nvd_key(self):
+        names = [p["name"] for p in IpToSecurityRisk.get_params_schema()]
+        assert "NVD_API_KEY" in names
+
+    def test_nvd_key_is_optional_vault_secret(self):
+        param = next(p for p in IpToSecurityRisk.get_params_schema() if p["name"] == "NVD_API_KEY")
+        assert param["type"] == "vaultSecret"
+        assert param["required"] is False
 
     def test_documentation_mentions_shodan(self):
-        doc = IpToSecurityRisk.documentation()
-        assert "Shodan" in doc
+        assert "Shodan" in IpToSecurityRisk.documentation()
+
+    def test_documentation_mentions_nvd(self):
+        assert "NVD" in IpToSecurityRisk.documentation()
 
     def test_documentation_mentions_risk_score(self):
-        doc = IpToSecurityRisk.documentation()
-        assert "risk" in doc.lower()
+        assert "risk" in IpToSecurityRisk.documentation().lower()
 
     def test_enricher_registered_in_global_registry(self):
         from flowsint_enrichers import ENRICHER_REGISTRY, load_all_enrichers
@@ -751,7 +997,7 @@ class TestEnricherMetadata:
 
 
 # ---------------------------------------------------------------------------
-# 6. Vault integration
+# 8. Vault integration
 # ---------------------------------------------------------------------------
 
 
@@ -767,46 +1013,62 @@ class TestVaultIntegration:
         return str(uuid.uuid4())
 
     @pytest.mark.asyncio
-    async def test_api_key_resolved_from_vault(self, mock_vault, sketch_id):
+    async def test_shodan_api_key_resolved_from_vault(self, mock_vault, sketch_id):
         mock_vault.get_secret.return_value = "my-shodan-key"
-
         enricher = IpToSecurityRisk(
-            sketch_id=sketch_id, scan_id="scan_1", vault=mock_vault, params={}
+            sketch_id=sketch_id, scan_id="s1", vault=mock_vault, params={}
         )
         enricher._graph_service = MagicMock()
         await enricher.async_init()
-
         calls = [c[0][0] for c in mock_vault.get_secret.call_args_list]
         assert "SHODAN_API_KEY" in calls
         assert enricher.get_secret("SHODAN_API_KEY") == "my-shodan-key"
 
     @pytest.mark.asyncio
-    async def test_missing_api_key_raises_on_async_init(self, mock_vault, sketch_id):
-        mock_vault.get_secret.return_value = None  # key not in vault
-
+    async def test_missing_shodan_key_raises_on_async_init(self, mock_vault, sketch_id):
+        mock_vault.get_secret.return_value = None
         enricher = IpToSecurityRisk(
-            sketch_id=sketch_id, scan_id="scan_1", vault=mock_vault, params={}
+            sketch_id=sketch_id, scan_id="s1", vault=mock_vault, params={}
         )
         enricher._graph_service = MagicMock()
-
         with pytest.raises(Exception) as exc_info:
             await enricher.async_init()
-
         assert "SHODAN_API_KEY" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_nvd_api_key_resolved_from_vault(self, mock_vault, sketch_id):
+        mock_vault.get_secret.side_effect = lambda name: (
+            "shodan-key" if name == "SHODAN_API_KEY" else
+            "nvd-key" if name == "NVD_API_KEY" else None
+        )
+        enricher = IpToSecurityRisk(
+            sketch_id=sketch_id, scan_id="s1", vault=mock_vault, params={}
+        )
+        enricher._graph_service = MagicMock()
+        await enricher.async_init()
+        assert enricher.get_secret("NVD_API_KEY") == "nvd-key"
+
+    @pytest.mark.asyncio
+    async def test_nvd_key_optional_enricher_still_inits_without_it(self, mock_vault, sketch_id):
+        # NVD key missing → no error (it's optional)
+        mock_vault.get_secret.side_effect = lambda name: (
+            "shodan-key" if name == "SHODAN_API_KEY" else None
+        )
+        enricher = IpToSecurityRisk(
+            sketch_id=sketch_id, scan_id="s1", vault=mock_vault, params={}
+        )
+        enricher._graph_service = MagicMock()
+        await enricher.async_init()  # must not raise
+        assert enricher.get_secret("SHODAN_API_KEY") == "shodan-key"
 
     @pytest.mark.asyncio
     async def test_user_provided_vault_id_takes_priority(self, mock_vault, sketch_id):
         vault_id = str(uuid.uuid4())
         mock_vault.get_secret.return_value = "resolved-key"
-
         enricher = IpToSecurityRisk(
-            sketch_id=sketch_id,
-            scan_id="scan_1",
-            vault=mock_vault,
+            sketch_id=sketch_id, scan_id="s1", vault=mock_vault,
             params={"SHODAN_API_KEY": vault_id},
         )
         enricher._graph_service = MagicMock()
         await enricher.async_init()
-
-        first_call = mock_vault.get_secret.call_args_list[0][0][0]
-        assert first_call == vault_id
+        assert mock_vault.get_secret.call_args_list[0][0][0] == vault_id

--- a/flowsint-enrichers/tests/enrichers/test_ip_to_security_risk.py
+++ b/flowsint-enrichers/tests/enrichers/test_ip_to_security_risk.py
@@ -1,0 +1,812 @@
+"""
+Tests for the ip_to_security_risk enricher.
+
+Coverage:
+- Pure scoring helpers (_compute_risk_score, _risk_level)
+- _build_risk_profile: various Shodan response shapes
+- scan(): happy path, missing API key, Shodan errors
+- postprocess(): graph node/relationship creation
+- Vault integration: SHODAN_API_KEY resolution and missing-key error
+"""
+
+import uuid
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from flowsint_enrichers.ip.to_security_risk import (
+    IpToSecurityRisk,
+    InputType,
+    OutputType,
+    _EVIDENCE_MULTIPLIERS,
+    _EXPOSURE_SCORES,
+    _EXPLOIT_SCORES,
+    _SENSITIVITY_UNKNOWN,
+    _CVSS_W,
+    _EXPOSURE_W,
+    _SENSITIVITY_W,
+    _EXPLOIT_W,
+    _compute_risk_score,
+    _risk_level,
+)
+from flowsint_types.ip import Ip
+from flowsint_types.port import Port
+from flowsint_types.risk_profile import RiskProfile
+
+
+# ---------------------------------------------------------------------------
+# Shared Shodan response fixtures
+# ---------------------------------------------------------------------------
+
+SHODAN_RICH: Dict[str, Any] = {
+    "ip_str": "1.2.3.4",
+    "org": "Acme Corp",
+    "asn": "AS12345",
+    "isp": "Acme ISP",
+    "country_name": "United States",
+    "city": "New York",
+    "hostnames": ["mail.example.com", "www.example.com"],
+    "domains": ["example.com"],
+    "ports": [22, 80, 443, 3306],
+    "data": [
+        {
+            "port": 22,
+            "transport": "tcp",
+            "_shodan": {"module": "ssh"},
+            "product": "OpenSSH",
+            "data": "SSH-2.0-OpenSSH_8.0\n",
+        },
+        {
+            "port": 80,
+            "transport": "tcp",
+            "_shodan": {"module": "http"},
+            "product": "nginx",
+            "data": "HTTP/1.1 200 OK\n",
+        },
+        {
+            "port": 443,
+            "transport": "tcp",
+            "_shodan": {"module": "https"},
+            "product": "nginx",
+            "data": "HTTP/1.1 200 OK\n",
+        },
+        {
+            "port": 3306,
+            "transport": "tcp",
+            "_shodan": {"module": "mysql"},
+            "product": "MySQL",
+            "data": "5.7.34\n",
+        },
+    ],
+    "vulns": {
+        "CVE-2021-44228": {"cvss": 10.0, "summary": "Log4Shell RCE"},
+        "CVE-2021-45046": {"cvss": 9.0, "summary": "Log4Shell variant"},
+    },
+}
+
+SHODAN_NO_CVES: Dict[str, Any] = {
+    "ip_str": "5.6.7.8",
+    "org": "Some ISP",
+    "country_name": "Germany",
+    "hostnames": [],
+    "domains": [],
+    "ports": [22, 80],
+    "data": [
+        {
+            "port": 22,
+            "transport": "tcp",
+            "_shodan": {"module": "ssh"},
+            "product": "OpenSSH",
+            "data": "SSH banner",
+        },
+        {
+            "port": 80,
+            "transport": "tcp",
+            "_shodan": {"module": "http"},
+            "product": "Apache",
+            "data": "HTTP/1.1 200 OK",
+        },
+    ],
+    "vulns": {},
+}
+
+SHODAN_MINIMAL: Dict[str, Any] = {
+    "ip_str": "9.9.9.9",
+    "ports": [12345],
+    "data": [],
+    "vulns": {},
+}
+
+SHODAN_RDP_EXPOSED: Dict[str, Any] = {
+    "ip_str": "2.3.4.5",
+    "ports": [3389],
+    "data": [
+        {
+            "port": 3389,
+            "transport": "tcp",
+            "_shodan": {"module": "rdp"},
+            "product": "Microsoft Terminal Services",
+            "data": "",
+        }
+    ],
+    "vulns": {},
+}
+
+SHODAN_CVSS_ZERO: Dict[str, Any] = {
+    "ip_str": "3.4.5.6",
+    "ports": [80],
+    "data": [
+        {
+            "port": 80,
+            "transport": "tcp",
+            "_shodan": {"module": "http"},
+            "product": "nginx",
+            "data": "HTTP/1.1 200 OK",
+        }
+    ],
+    "vulns": {
+        "CVE-2023-00001": {"cvss": 0.0, "summary": "Some CVE with missing CVSS"},
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_enricher(api_key: str = "test-shodan-key", graph_service=None) -> IpToSecurityRisk:
+    """Construct an enricher with a pre-resolved API key and a mocked graph service."""
+    mock_vault = Mock()
+    mock_vault.get_secret.return_value = api_key
+
+    enricher = IpToSecurityRisk(
+        sketch_id=str(uuid.uuid4()),
+        scan_id="test-scan",
+        vault=mock_vault,
+        params={},
+    )
+
+    # Inject a mock graph service so no real Neo4j connection is needed
+    enricher._graph_service = graph_service or MagicMock()
+    # Pre-set params to avoid needing async_init in most tests
+    enricher.params = {"SHODAN_API_KEY": api_key}
+    return enricher
+
+
+# ---------------------------------------------------------------------------
+# 1. Pure scoring helpers
+# ---------------------------------------------------------------------------
+
+
+class TestRiskLevel:
+    def test_critical_at_75(self):
+        assert _risk_level(75.0) == "critical"
+
+    def test_critical_above_75(self):
+        assert _risk_level(99.9) == "critical"
+
+    def test_high_at_50(self):
+        assert _risk_level(50.0) == "high"
+
+    def test_high_below_75(self):
+        assert _risk_level(74.9) == "high"
+
+    def test_medium_at_25(self):
+        assert _risk_level(25.0) == "medium"
+
+    def test_medium_below_50(self):
+        assert _risk_level(49.9) == "medium"
+
+    def test_low_below_25(self):
+        assert _risk_level(24.9) == "low"
+
+    def test_low_at_zero(self):
+        assert _risk_level(0.0) == "low"
+
+
+class TestComputeRiskScore:
+    def test_score_is_bounded_0_to_100(self):
+        score = _compute_risk_score(10.0, "internet_facing", "active_exploitation", "correlated")
+        assert 0.0 <= score <= 100.0
+
+    def test_high_cvss_internet_facing_exploit_yields_critical(self):
+        score = _compute_risk_score(10.0, "internet_facing", "public_exploit", "correlated")
+        assert score >= 75.0
+
+    def test_zero_cvss_internal_no_exploit_yields_low(self):
+        score = _compute_risk_score(0.0, "internal", "no_exploit", "inferred")
+        assert score < 50.0
+
+    def test_internet_facing_scores_higher_than_internal(self):
+        score_internet = _compute_risk_score(5.0, "internet_facing", "unknown", "inferred")
+        score_internal = _compute_risk_score(5.0, "internal", "unknown", "inferred")
+        assert score_internet > score_internal
+
+    def test_correlated_evidence_scores_higher_than_inferred(self):
+        score_corr = _compute_risk_score(5.0, "internet_facing", "unknown", "correlated")
+        score_inf = _compute_risk_score(5.0, "internet_facing", "unknown", "inferred")
+        assert score_corr > score_inf
+
+    def test_public_exploit_scores_higher_than_no_exploit(self):
+        score_exploit = _compute_risk_score(5.0, "internet_facing", "public_exploit", "correlated")
+        score_none = _compute_risk_score(5.0, "internet_facing", "no_exploit", "correlated")
+        assert score_exploit > score_none
+
+    def test_formula_matches_manual_calculation(self):
+        # CVSS=8.0, internet_facing(100), public_exploit(65), correlated(0.95)
+        cvss_norm = (8.0 / 10.0) * 100.0  # 80
+        base = (
+            80.0 * _CVSS_W
+            + 100.0 * _EXPOSURE_W
+            + _SENSITIVITY_UNKNOWN * _SENSITIVITY_W
+            + 65.0 * _EXPLOIT_W
+        )
+        expected = round(base * _EVIDENCE_MULTIPLIERS["correlated"], 2)
+        assert _compute_risk_score(8.0, "internet_facing", "public_exploit", "correlated") == expected
+
+    def test_unknown_exposure_uses_50(self):
+        score = _compute_risk_score(5.0, "unknown", "unknown", "unknown")
+        # Must use EXPOSURE_SCORES["unknown"] = 50
+        cvss_norm = 50.0
+        base = (
+            cvss_norm * _CVSS_W
+            + 50.0 * _EXPOSURE_W
+            + _SENSITIVITY_UNKNOWN * _SENSITIVITY_W
+            + 30.0 * _EXPLOIT_W
+        )
+        expected = round(base * _EVIDENCE_MULTIPLIERS["unknown"], 2)
+        assert score == expected
+
+
+# ---------------------------------------------------------------------------
+# 2. _build_risk_profile — Shodan response parsing
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRiskProfile:
+    def setup_method(self):
+        self.enricher = _make_enricher()
+
+    def _build(self, address: str, host: Dict[str, Any]) -> RiskProfile:
+        return self.enricher._build_risk_profile(address, host)
+
+    # --- RiskProfile fields --------------------------------------------------
+
+    def test_entity_id_matches_address(self):
+        profile = self._build("1.2.3.4", SHODAN_RICH)
+        assert profile.entity_id == "1.2.3.4"
+
+    def test_entity_type_is_ip(self):
+        profile = self._build("1.2.3.4", SHODAN_RICH)
+        assert profile.entity_type == "IP"
+
+    def test_source_is_shodan(self):
+        profile = self._build("1.2.3.4", SHODAN_RICH)
+        assert profile.source == "Shodan"
+
+    def test_assessment_date_is_set(self):
+        profile = self._build("1.2.3.4", SHODAN_RICH)
+        assert profile.assessment_date is not None
+        assert "Z" in profile.assessment_date
+
+    def test_risk_level_is_valid_string(self):
+        profile = self._build("1.2.3.4", SHODAN_RICH)
+        assert profile.risk_level in ("low", "medium", "high", "critical")
+
+    def test_overall_risk_score_in_range(self):
+        profile = self._build("1.2.3.4", SHODAN_RICH)
+        assert 0.0 <= profile.overall_risk_score <= 100.0
+
+    # --- CVE handling --------------------------------------------------------
+
+    def test_cves_extracted_from_rich_response(self):
+        profile = self._build("1.2.3.4", SHODAN_RICH)
+        assert profile.vulnerabilities is not None
+        assert "CVE-2021-44228" in profile.vulnerabilities
+        assert "CVE-2021-45046" in profile.vulnerabilities
+
+    def test_no_cves_when_vulns_empty(self):
+        profile = self._build("5.6.7.8", SHODAN_NO_CVES)
+        assert not profile.vulnerabilities
+
+    def test_cvss_floor_applied_when_cves_present_but_cvss_zero(self):
+        # CVE exists with CVSS=0 → must be floored to 6.5 before scoring
+        profile_floored = self._build("3.4.5.6", SHODAN_CVSS_ZERO)
+        # Compute what score WOULD be with CVSS=6.5 (floor)
+        expected_score = _compute_risk_score(6.5, "internet_facing", "public_exploit", "correlated")
+        assert profile_floored.overall_risk_score == expected_score
+
+    def test_high_cvss_produces_higher_score_than_low(self):
+        profile_high = self._build("1.2.3.4", SHODAN_RICH)   # CVSS 10.0
+        profile_low = self._build("5.6.7.8", SHODAN_NO_CVES)  # no CVEs → CVSS 0
+        assert profile_high.overall_risk_score > profile_low.overall_risk_score
+
+    # --- Exposure detection --------------------------------------------------
+
+    def test_internet_facing_via_service_name(self):
+        # SHODAN_RICH has ssh/http/https/mysql modules → internet_facing
+        profile = self._build("1.2.3.4", SHODAN_RICH)
+        assert profile.exposure_surface is not None
+        # risk_factors should mention internet-facing
+        assert profile.risk_factors is not None
+        assert any("internet" in f.lower() for f in profile.risk_factors)
+
+    def test_internet_facing_via_well_known_port_number(self):
+        # Port 443 is in the known-ports set even if module name not recognised
+        host = {
+            "ip_str": "1.2.3.4",
+            "ports": [443],
+            "data": [{"port": 443, "transport": "tcp", "_shodan": {"module": ""}, "data": ""}],
+            "vulns": {},
+        }
+        profile = self._build("1.2.3.4", host)
+        assert any("internet" in f.lower() for f in (profile.risk_factors or []))
+
+    def test_non_internet_facing_port_classified_unknown(self):
+        # Only port 12345 open, no service name, no known-port match
+        profile = self._build("9.9.9.9", SHODAN_MINIMAL)
+        # No internet-facing risk factor expected
+        internet_factors = [f for f in (profile.risk_factors or []) if "internet" in f.lower()]
+        assert len(internet_factors) == 0
+
+    # --- Exploit status and evidence -----------------------------------------
+
+    def test_exploit_status_public_when_cves_present(self):
+        # When CVEs exist, exploit_status → public_exploit, evidence → correlated
+        # Risk score should use public_exploit (65) and correlated (0.95)
+        profile = self._build("1.2.3.4", SHODAN_RICH)
+        expected = _compute_risk_score(10.0, "internet_facing", "public_exploit", "correlated")
+        assert profile.overall_risk_score == expected
+
+    def test_exploit_status_unknown_when_no_cves(self):
+        # No CVEs, internet-facing → unknown exploit, inferred evidence
+        profile = self._build("5.6.7.8", SHODAN_NO_CVES)
+        expected = _compute_risk_score(0.0, "internet_facing", "unknown", "inferred")
+        assert profile.overall_risk_score == expected
+
+    def test_minimal_host_uses_unknown_evidence(self):
+        # No data[], no vulns → unknown evidence
+        profile = self._build("9.9.9.9", SHODAN_MINIMAL)
+        expected = _compute_risk_score(0.0, "unknown", "unknown", "unknown")
+        assert profile.overall_risk_score == expected
+
+    # --- Risk factors ---------------------------------------------------------
+
+    def test_rdp_exposure_adds_risk_factor(self):
+        profile = self._build("2.3.4.5", SHODAN_RDP_EXPOSED)
+        assert profile.risk_factors is not None
+        assert any("RDP" in f for f in profile.risk_factors)
+
+    def test_ssh_exposure_adds_risk_factor(self):
+        profile = self._build("1.2.3.4", SHODAN_RICH)
+        assert profile.risk_factors is not None
+        assert any("SSH" in f for f in profile.risk_factors)
+
+    def test_database_exposure_adds_risk_factor(self):
+        profile = self._build("1.2.3.4", SHODAN_RICH)  # has port 3306
+        assert profile.risk_factors is not None
+        assert any("Database" in f or "database" in f for f in profile.risk_factors)
+
+    def test_critical_cvss_adds_risk_factor(self):
+        profile = self._build("1.2.3.4", SHODAN_RICH)  # CVSS 10.0
+        assert any("Critical" in f or "CVSS ≥ 9" in f for f in (profile.risk_factors or []))
+
+    # --- Compliance risks -----------------------------------------------------
+
+    def test_pci_compliance_risk_when_high_cvss_cves(self):
+        profile = self._build("1.2.3.4", SHODAN_RICH)
+        assert profile.compliance_risks is not None
+        assert any("PCI" in r for r in profile.compliance_risks)
+
+    def test_gdpr_compliance_risk_when_database_exposed(self):
+        profile = self._build("1.2.3.4", SHODAN_RICH)  # port 3306
+        assert profile.compliance_risks is not None
+        assert any("GDPR" in r for r in profile.compliance_risks)
+
+    def test_no_compliance_risks_for_minimal_host(self):
+        profile = self._build("9.9.9.9", SHODAN_MINIMAL)
+        # No CVEs above CVSS 7.0, no DB ports → empty compliance_risks
+        assert not profile.compliance_risks
+
+    # --- Mitigations ----------------------------------------------------------
+
+    def test_mitigations_non_empty_for_rich_host(self):
+        profile = self._build("1.2.3.4", SHODAN_RICH)
+        assert profile.mitigation_strategies
+        assert len(profile.mitigation_strategies) > 0
+
+    def test_rdp_mitigation_recommended(self):
+        profile = self._build("2.3.4.5", SHODAN_RDP_EXPOSED)
+        assert profile.mitigation_strategies is not None
+        assert any("RDP" in m for m in profile.mitigation_strategies)
+
+    def test_cve_patch_recommendation_included(self):
+        profile = self._build("1.2.3.4", SHODAN_RICH)
+        assert profile.mitigation_strategies is not None
+        assert any("CVE" in m for m in profile.mitigation_strategies)
+
+    # --- Exposure surface metadata -------------------------------------------
+
+    def test_org_in_exposure_surface(self):
+        profile = self._build("1.2.3.4", SHODAN_RICH)
+        assert profile.exposure_surface is not None
+        assert "Acme Corp" in profile.exposure_surface
+
+    def test_asn_in_exposure_surface(self):
+        profile = self._build("1.2.3.4", SHODAN_RICH)
+        assert "AS12345" in profile.exposure_surface
+
+    def test_country_in_exposure_surface(self):
+        profile = self._build("1.2.3.4", SHODAN_RICH)
+        assert "United States" in profile.exposure_surface
+
+    def test_open_ports_listed_in_exposure_surface(self):
+        profile = self._build("1.2.3.4", SHODAN_RICH)
+        assert "22" in profile.exposure_surface
+        assert "443" in profile.exposure_surface
+
+    # --- Temp attribute for postprocess ---------------------------------------
+
+    def test_shodan_ports_stored_as_temp_attribute(self):
+        profile = self._build("1.2.3.4", SHODAN_RICH)
+        ports = getattr(profile, "_shodan_ports", None)
+        assert ports is not None
+        assert len(ports) == 4  # 22, 80, 443, 3306
+        numbers = {p["number"] for p in ports}
+        assert numbers == {22, 80, 443, 3306}
+
+    def test_port_service_names_captured(self):
+        profile = self._build("1.2.3.4", SHODAN_RICH)
+        ports = getattr(profile, "_shodan_ports", [])
+        port_22 = next(p for p in ports if p["number"] == 22)
+        assert port_22["service"] == "ssh"
+
+    def test_fallback_to_ports_list_when_no_banner_data(self):
+        profile = self._build("9.9.9.9", SHODAN_MINIMAL)  # data=[], ports=[12345]
+        ports = getattr(profile, "_shodan_ports", [])
+        assert len(ports) == 1
+        assert ports[0]["number"] == 12345
+
+    # --- Confidence -----------------------------------------------------------
+
+    def test_confidence_higher_when_cves_present(self):
+        profile_with_cves = self._build("1.2.3.4", SHODAN_RICH)
+        profile_without_cves = self._build("5.6.7.8", SHODAN_NO_CVES)
+        assert profile_with_cves.confidence > profile_without_cves.confidence
+
+
+# ---------------------------------------------------------------------------
+# 3. scan() — async, mocked Shodan API
+# ---------------------------------------------------------------------------
+
+
+class TestScan:
+    def setup_method(self):
+        self.enricher = _make_enricher()
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_when_api_key_missing(self):
+        self.enricher.params = {}  # no SHODAN_API_KEY
+        results = await self.enricher.scan([Ip(address="1.2.3.4")])
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_when_shodan_not_installed(self):
+        with patch.dict("sys.modules", {"shodan": None}):
+            results = await self.enricher.scan([Ip(address="1.2.3.4")])
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_one_profile_per_ip(self):
+        mock_api = MagicMock()
+        mock_api.host.return_value = SHODAN_RICH
+
+        with patch("flowsint_enrichers.ip.to_security_risk.shodan") as mock_shodan_mod:
+            mock_shodan_mod.Shodan.return_value = mock_api
+            mock_shodan_mod.APIError = Exception
+
+            results = await self.enricher.scan([Ip(address="1.2.3.4")])
+
+        assert len(results) == 1
+        assert isinstance(results[0], RiskProfile)
+        assert results[0].entity_id == "1.2.3.4"
+
+    @pytest.mark.asyncio
+    async def test_multiple_ips_each_get_a_profile(self):
+        mock_api = MagicMock()
+        mock_api.host.side_effect = [SHODAN_RICH, SHODAN_NO_CVES]
+
+        with patch("flowsint_enrichers.ip.to_security_risk.shodan") as mock_shodan_mod:
+            mock_shodan_mod.Shodan.return_value = mock_api
+            mock_shodan_mod.APIError = Exception
+
+            results = await self.enricher.scan([
+                Ip(address="1.2.3.4"),
+                Ip(address="5.6.7.8"),
+            ])
+
+        assert len(results) == 2
+        assert results[0].entity_id == "1.2.3.4"
+        assert results[1].entity_id == "5.6.7.8"
+
+    @pytest.mark.asyncio
+    async def test_shodan_api_error_skips_ip_gracefully(self):
+        class FakeShodanAPIError(Exception):
+            pass
+
+        mock_api = MagicMock()
+        mock_api.host.side_effect = FakeShodanAPIError("No information available")
+
+        with patch("flowsint_enrichers.ip.to_security_risk.shodan") as mock_shodan_mod:
+            mock_shodan_mod.Shodan.return_value = mock_api
+            mock_shodan_mod.APIError = FakeShodanAPIError
+
+            results = await self.enricher.scan([Ip(address="1.2.3.4")])
+
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_skips_ip_gracefully(self):
+        mock_api = MagicMock()
+        mock_api.host.side_effect = RuntimeError("connection reset")
+
+        with patch("flowsint_enrichers.ip.to_security_risk.shodan") as mock_shodan_mod:
+            mock_shodan_mod.Shodan.return_value = mock_api
+            mock_shodan_mod.APIError = Exception  # RuntimeError won't match this
+
+            results = await self.enricher.scan([Ip(address="1.2.3.4")])
+
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_one_ip_fails_others_still_processed(self):
+        class FakeShodanAPIError(Exception):
+            pass
+
+        mock_api = MagicMock()
+        mock_api.host.side_effect = [
+            FakeShodanAPIError("No info"),  # first IP fails
+            SHODAN_NO_CVES,                  # second IP succeeds
+        ]
+
+        with patch("flowsint_enrichers.ip.to_security_risk.shodan") as mock_shodan_mod:
+            mock_shodan_mod.Shodan.return_value = mock_api
+            mock_shodan_mod.APIError = FakeShodanAPIError
+
+            results = await self.enricher.scan([
+                Ip(address="1.2.3.4"),
+                Ip(address="5.6.7.8"),
+            ])
+
+        assert len(results) == 1
+        assert results[0].entity_id == "5.6.7.8"
+
+    @pytest.mark.asyncio
+    async def test_shodan_called_with_correct_ip(self):
+        mock_api = MagicMock()
+        mock_api.host.return_value = SHODAN_RICH
+
+        with patch("flowsint_enrichers.ip.to_security_risk.shodan") as mock_shodan_mod:
+            mock_shodan_mod.Shodan.return_value = mock_api
+            mock_shodan_mod.APIError = Exception
+
+            await self.enricher.scan([Ip(address="1.2.3.4")])
+
+        mock_api.host.assert_called_once_with("1.2.3.4")
+
+    @pytest.mark.asyncio
+    async def test_shodan_initialised_with_api_key(self):
+        mock_api = MagicMock()
+        mock_api.host.return_value = SHODAN_RICH
+
+        with patch("flowsint_enrichers.ip.to_security_risk.shodan") as mock_shodan_mod:
+            mock_shodan_mod.Shodan.return_value = mock_api
+            mock_shodan_mod.APIError = Exception
+
+            await self.enricher.scan([Ip(address="1.2.3.4")])
+
+        mock_shodan_mod.Shodan.assert_called_once_with("test-shodan-key")
+
+
+# ---------------------------------------------------------------------------
+# 4. postprocess() — graph node/relationship creation
+# ---------------------------------------------------------------------------
+
+
+class TestPostprocess:
+    def setup_method(self):
+        self.graph = MagicMock()
+        self.enricher = _make_enricher(graph_service=self.graph)
+
+    def _profile_with_ports(self, address: str = "1.2.3.4") -> RiskProfile:
+        profile = self.enricher._build_risk_profile(address, SHODAN_RICH)
+        return profile
+
+    def test_creates_ip_node(self):
+        profile = self._profile_with_ports()
+        self.enricher.postprocess([profile], [Ip(address="1.2.3.4")])
+        calls = [str(c) for c in self.graph.create_node_from_flowsint_type.call_args_list]
+        assert any("1.2.3.4" in c for c in calls)
+
+    def test_creates_risk_profile_node(self):
+        profile = self._profile_with_ports()
+        self.enricher.postprocess([profile], [Ip(address="1.2.3.4")])
+        # At minimum two nodes: IP + RiskProfile
+        assert self.graph.create_node_from_flowsint_type.call_count >= 2
+
+    def test_creates_has_risk_profile_relationship(self):
+        profile = self._profile_with_ports()
+        self.enricher.postprocess([profile], [Ip(address="1.2.3.4")])
+        rel_labels = [
+            call.args[2] if call.args else call.kwargs.get("rel_label")
+            for call in self.graph.create_relationship.call_args_list
+        ]
+        assert "HAS_RISK_PROFILE" in rel_labels
+
+    def test_creates_has_port_relationships_for_each_port(self):
+        profile = self._profile_with_ports()
+        self.enricher.postprocess([profile], [Ip(address="1.2.3.4")])
+        rel_labels = [
+            call.args[2] if call.args else call.kwargs.get("rel_label")
+            for call in self.graph.create_relationship.call_args_list
+        ]
+        # SHODAN_RICH has 4 ports → 4 HAS_PORT relationships + 1 HAS_RISK_PROFILE
+        assert rel_labels.count("HAS_PORT") == 4
+
+    def test_temp_attribute_cleaned_up_after_postprocess(self):
+        profile = self._profile_with_ports()
+        assert hasattr(profile, "_shodan_ports")
+        self.enricher.postprocess([profile], [Ip(address="1.2.3.4")])
+        assert not hasattr(profile, "_shodan_ports")
+
+    def test_no_crash_when_graph_service_is_none(self):
+        self.enricher._graph_service = None
+        profile = self._profile_with_ports()
+        result = self.enricher.postprocess([profile], [Ip(address="1.2.3.4")])
+        assert result == [profile]
+
+    def test_returns_results_unchanged(self):
+        profile = self._profile_with_ports()
+        result = self.enricher.postprocess([profile], [Ip(address="1.2.3.4")])
+        assert result == [profile]
+
+    def test_handles_empty_results(self):
+        result = self.enricher.postprocess([], [])
+        assert result == []
+
+    def test_flush_called_on_graph_service(self):
+        # The base execute() calls flush(), but postprocess should not need to.
+        # This test just ensures postprocess runs without error when flush IS called.
+        profile = self._profile_with_ports()
+        self.enricher.postprocess([profile], [Ip(address="1.2.3.4")])
+        # No assertion — just checks no exception is raised
+
+    def test_ip_reconstructed_when_not_in_input_data(self):
+        # If input_data is None, IP node should still be created from entity_id
+        profile = self._profile_with_ports()
+        self.enricher.postprocess([profile], None)
+        self.graph.create_node_from_flowsint_type.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# 5. Enricher metadata / registration
+# ---------------------------------------------------------------------------
+
+
+class TestEnricherMetadata:
+    def test_name(self):
+        assert IpToSecurityRisk.name() == "ip_to_security_risk"
+
+    def test_category(self):
+        assert IpToSecurityRisk.category() == "Ip"
+
+    def test_key(self):
+        assert IpToSecurityRisk.key() == "address"
+
+    def test_input_type_is_ip(self):
+        assert InputType is Ip
+
+    def test_output_type_is_risk_profile(self):
+        assert OutputType is RiskProfile
+
+    def test_input_schema_type(self):
+        schema = IpToSecurityRisk.input_schema()
+        assert schema["type"] == "Ip"
+
+    def test_output_schema_type(self):
+        schema = IpToSecurityRisk.output_schema()
+        assert schema["type"] == "RiskProfile"
+
+    def test_required_params_is_true(self):
+        assert IpToSecurityRisk.required_params() is True
+
+    def test_params_schema_declares_shodan_key(self):
+        schema = IpToSecurityRisk.get_params_schema()
+        names = [p["name"] for p in schema]
+        assert "SHODAN_API_KEY" in names
+
+    def test_shodan_key_param_is_vault_secret(self):
+        schema = IpToSecurityRisk.get_params_schema()
+        shodan_param = next(p for p in schema if p["name"] == "SHODAN_API_KEY")
+        assert shodan_param["type"] == "vaultSecret"
+
+    def test_shodan_key_param_is_required(self):
+        schema = IpToSecurityRisk.get_params_schema()
+        shodan_param = next(p for p in schema if p["name"] == "SHODAN_API_KEY")
+        assert shodan_param["required"] is True
+
+    def test_documentation_mentions_shodan(self):
+        doc = IpToSecurityRisk.documentation()
+        assert "Shodan" in doc
+
+    def test_documentation_mentions_risk_score(self):
+        doc = IpToSecurityRisk.documentation()
+        assert "risk" in doc.lower()
+
+    def test_enricher_registered_in_global_registry(self):
+        from flowsint_enrichers import ENRICHER_REGISTRY, load_all_enrichers
+        load_all_enrichers()
+        assert ENRICHER_REGISTRY.enricher_exists("ip_to_security_risk")
+
+
+# ---------------------------------------------------------------------------
+# 6. Vault integration
+# ---------------------------------------------------------------------------
+
+
+class TestVaultIntegration:
+    @pytest.fixture
+    def mock_vault(self):
+        vault = Mock()
+        vault.get_secret = Mock()
+        return vault
+
+    @pytest.fixture
+    def sketch_id(self):
+        return str(uuid.uuid4())
+
+    @pytest.mark.asyncio
+    async def test_api_key_resolved_from_vault(self, mock_vault, sketch_id):
+        mock_vault.get_secret.return_value = "my-shodan-key"
+
+        enricher = IpToSecurityRisk(
+            sketch_id=sketch_id, scan_id="scan_1", vault=mock_vault, params={}
+        )
+        enricher._graph_service = MagicMock()
+        await enricher.async_init()
+
+        calls = [c[0][0] for c in mock_vault.get_secret.call_args_list]
+        assert "SHODAN_API_KEY" in calls
+        assert enricher.get_secret("SHODAN_API_KEY") == "my-shodan-key"
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key_raises_on_async_init(self, mock_vault, sketch_id):
+        mock_vault.get_secret.return_value = None  # key not in vault
+
+        enricher = IpToSecurityRisk(
+            sketch_id=sketch_id, scan_id="scan_1", vault=mock_vault, params={}
+        )
+        enricher._graph_service = MagicMock()
+
+        with pytest.raises(Exception) as exc_info:
+            await enricher.async_init()
+
+        assert "SHODAN_API_KEY" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_user_provided_vault_id_takes_priority(self, mock_vault, sketch_id):
+        vault_id = str(uuid.uuid4())
+        mock_vault.get_secret.return_value = "resolved-key"
+
+        enricher = IpToSecurityRisk(
+            sketch_id=sketch_id,
+            scan_id="scan_1",
+            vault=mock_vault,
+            params={"SHODAN_API_KEY": vault_id},
+        )
+        enricher._graph_service = MagicMock()
+        await enricher.async_init()
+
+        first_call = mock_vault.get_secret.call_args_list[0][0][0]
+        assert first_call == vault_id


### PR DESCRIPTION
## Summary

- Adds a new **`ip_to_security_risk`** enricher under `flowsint-enrichers/src/flowsint_enrichers/ip/to_security_risk.py`
- Takes an `Ip` node → queries Shodan → emits a `RiskProfile` node + `Port` nodes, all linked in the graph
- Adds `shodan>=1.31,<2.0` to `flowsint-enrichers` dependencies

## What problem does this solve?

Flowsint already excels at mapping entity relationships (domains, IPs, social accounts, etc.), but it has no native way to **score the security danger** of an IP node. An investigator looking at an IP in the graph has no immediate signal of how risky it is.

This enricher fills that gap: it enriches an IP with a **0–100 risk score**, a **critical / high / medium / low** classification, CVE IDs, exposure-surface summary, compliance risk flags, and mitigation recommendations — all surfaced as a `RiskProfile` node linked directly to the IP.

## Scoring model

Adapted from **RedFlag**, an open-source M&A cybersecurity due-diligence tool, the formula combines four weighted factors:

```
score = (cvss_norm × 0.35)        ← how severe are the CVEs?
      + (exposure  × 0.25)        ← is this internet-facing?
      + (sensitivity × 0.25)      ← data classification (always UNKNOWN — no asset inventory)
      + (exploit   × 0.15)        ← are CVEs weaponised?
      × evidence_multiplier        ← how confident is the data?
```

| Factor | Value | Score |
|--------|-------|-------|
| Exposure | Internet-facing (HTTP/SSH/RDP/DB ports) | 100 |
| Exposure | Unknown | 50 |
| Exploit status | Public CVE linked by Shodan | 65 |
| Exploit status | No CVE data | 30 |
| Evidence | CORRELATED — CVEs + port confirmed | ×0.95 |
| Evidence | INFERRED — host found, no CVEs | ×0.85 |

Risk level bands: **critical** ≥ 75 · **high** ≥ 50 · **medium** ≥ 25 · **low** < 25

## Graph output

```
(Ip) -[HAS_RISK_PROFILE]-> (RiskProfile)
(Ip) -[HAS_PORT]->         (Port)          ← one per open Shodan port
```

The `RiskProfile` node carries:
- `overall_risk_score` (0–100), `risk_level`, `assessment_date`
- `vulnerabilities` (CVE IDs), `risk_factors`, `attack_vectors`
- `exposure_surface` (org, ASN, hostnames, open ports)
- `compliance_risks` (PCI-DSS / GDPR / ISO 27001 flags)
- `mitigation_strategies`, `confidence`, `source = "Shodan"`

## Required vault secret

| Key | Where to get it |
|-----|----------------|
| `SHODAN_API_KEY` | https://account.shodan.io — 1 credit per `api.host()` call |

## Test plan

- [x] Add `SHODAN_API_KEY` to Flowsint vault
- [x] Open any `Ip` node in the investigation graph
- [x] Run enricher `ip_to_security_risk` on it
- [x] Verify `RiskProfile` node appears linked via `HAS_RISK_PROFILE`
- [x] Verify `Port` nodes appear linked via `HAS_PORT`
- [x] Confirm score and risk level are plausible for the IP under test
- [x] Confirm a Shodan-rate-limited or invalid key returns a graceful log warning, not a crash

## Files changed

| File | Change |
|------|--------|
| `flowsint-enrichers/src/flowsint_enrichers/ip/to_security_risk.py` | **New** — full enricher implementation |
| `flowsint-enrichers/pyproject.toml` | Added `shodan>=1.31,<2.0` dependency |
