### PR TITLE
fix: use aware timestamp for investigation updates

### DIFF
--- a/flowsint-core/src/flowsint_core/core/services/investigation_service.py
+++ b/flowsint-core/src/flowsint_core/core/services/investigation_service.py
@@ -4,7 +4,7 @@ Investigation service for managing investigations and user roles.
 
 from typing import List, Optional
 from uuid import UUID, uuid4
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy.orm import Session
 
@@ -109,7 +109,7 @@ class InvestigationService(BaseService):
         investigation.name = name
         investigation.description = description
         investigation.status = status
-        investigation.last_updated_at = datetime.utcnow()
+        investigation.last_updated_at = datetime.now(timezone.utc)
 
         self._commit()
         self._refresh(investigation)

--- a/flowsint-core/tests/services/test_timezone_timestamps.py
+++ b/flowsint-core/tests/services/test_timezone_timestamps.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 from flowsint_core.core.services.analysis_service import AnalysisService
 from flowsint_core.core.services.chat_service import ChatService
 from flowsint_core.core.services.flow_service import FlowService
+from flowsint_core.core.services.investigation_service import InvestigationService
 
 
 def _assert_utc(value):
@@ -70,3 +71,27 @@ def test_flow_service_create_uses_timezone_aware_timestamps():
 
     _assert_utc(flow.created_at)
     _assert_utc(flow.last_updated_at)
+
+
+def test_investigation_service_update_uses_timezone_aware_timestamp():
+    investigation = MagicMock()
+    investigation_repo = MagicMock()
+    investigation_repo.get_by_id.return_value = investigation
+    service = InvestigationService(
+        db=MagicMock(),
+        investigation_repo=investigation_repo,
+        sketch_repo=MagicMock(),
+        analysis_repo=MagicMock(),
+        profile_repo=MagicMock(),
+    )
+    service._check_permission = MagicMock()
+
+    service.update(
+        investigation_id=uuid4(),
+        user_id=uuid4(),
+        name="Updated investigation",
+        description="Updated description",
+        status="active",
+    )
+
+    _assert_utc(investigation.last_updated_at)


### PR DESCRIPTION
## Summary
- use `datetime.now(timezone.utc)` when updating an investigation timestamp
- extend the timezone timestamp regression tests to cover `InvestigationService.update()`

## Before / after
Before, `InvestigationService.update()` assigned `last_updated_at` with a naive UTC `datetime.utcnow()` value, while nearby service timestamp paths now use timezone-aware UTC values.

After, investigation updates store an aware UTC datetime, keeping the service layer consistent.

## Verification
- `python -m py_compile flowsint-core\src\flowsint_core\core\services\investigation_service.py flowsint-core\tests\services\test_timezone_timestamps.py`

I also attempted `python -m pytest flowsint-core\tests\services\test_timezone_timestamps.py`. With `PYTHONPATH=flowsint-core\src`, collection reached project imports but stopped because this local workspace is missing `passlib`.