### PR TITLE
fix(sse): replace EventSource with fetch-event-source for secure auth headers

### DIFF
--- a/flowsint-api/app/api/deps.py
+++ b/flowsint-api/app/api/deps.py
@@ -35,22 +35,20 @@ def get_current_user_sse(
     request: Request, db: Session = Depends(get_db)
 ) -> Profile:
     """
-    Alternative authentication for SSE endpoints that accepts token via query parameter.
-    EventSource API doesn't support custom headers, so we need to pass the token in the URL.
+    Authentication for SSE endpoints via Authorization header.
+    Uses fetch-event-source on the client side, which supports custom headers
+    unlike the native EventSource API.
     """
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Could not validate credentials",
     )
 
-    # Try to get token from query parameter
-    token: Optional[str] = request.query_params.get("token")
+    token: Optional[str] = None
 
-    # Fallback to Authorization header if query param not present
-    if not token:
-        auth_header = request.headers.get("Authorization")
-        if auth_header and auth_header.startswith("Bearer "):
-            token = auth_header.replace("Bearer ", "")
+    auth_header = request.headers.get("Authorization")
+    if auth_header and auth_header.startswith("Bearer "):
+        token = auth_header.replace("Bearer ", "")
 
     if not token:
         raise credentials_exception

--- a/flowsint-app/package.json
+++ b/flowsint-app/package.json
@@ -19,6 +19,7 @@
     "@ai-sdk/react": "^3.0.79",
     "@dagrejs/dagre": "^1.1.4",
     "@hookform/resolvers": "^5.0.1",
+    "@microsoft/fetch-event-source": "^2.0.1",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-alert-dialog": "^1.1.14",

--- a/flowsint-app/src/hooks/use-events.ts
+++ b/flowsint-app/src/hooks/use-events.ts
@@ -1,11 +1,11 @@
 import { useEffect, useState, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
+import { fetchEventSource } from '@microsoft/fetch-event-source'
 import { logService } from '@/api/log-service'
 import { queryKeys } from '@/api/query-keys'
 import { useAuthStore } from '@/stores/auth-store'
 
 const API_URL = import.meta.env.VITE_API_URL
-
 
 export function useEvents(sketch_id: string | undefined) {
   const [liveLogs, setLiveLogs] = useState<Event[]>([])
@@ -30,44 +30,48 @@ export function useEvents(sketch_id: string | undefined) {
   useEffect(() => {
     if (!sketch_id || !token) return
 
-    const eventSource = new EventSource(
-      `${API_URL}/api/events/sketch/${sketch_id}/stream?token=${token}`
-    )
+    const controller = new AbortController()
 
-    eventSource.onmessage = (e) => {
-      try {
-        // Handle malformed SSE data (connection message has extra "data: " prefix)
-        let dataStr = e.data
-        if (dataStr.startsWith('data: ')) {
-          dataStr = dataStr.substring(6) // Remove "data: " prefix
+    fetchEventSource(`${API_URL}/api/events/sketch/${sketch_id}/stream`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      signal: controller.signal,
+      onmessage(e) {
+        try {
+          // Handle malformed SSE data (connection message has extra "data: " prefix)
+          let dataStr = e.data
+          if (dataStr.startsWith('data: ')) {
+            dataStr = dataStr.substring(6) // Remove "data: " prefix
+          }
+
+          const raw = JSON.parse(dataStr) as any
+
+          // Ignore connection messages
+          if (raw.event === 'connected') {
+            return
+          }
+
+          // Only process log events
+          if (raw.event !== 'log') {
+            return
+          }
+
+          const event = JSON.parse(raw.data) as Event
+          setLiveLogs((prev) => [...prev.slice(-99), event])
+        } catch (error) {
+          console.error('[useSketchEvents] Failed to parse SSE event:', error, e.data)
         }
-
-        const raw = JSON.parse(dataStr) as any
-
-        // Ignore connection messages
-        if (raw.event === 'connected') {
-          return
-        }
-
-        // Only process log events
-        if (raw.event !== 'log') {
-          return
-        }
-
-        const event = JSON.parse(raw.data) as Event
-        setLiveLogs((prev) => [...prev.slice(-99), event])
-      } catch (error) {
-        console.error('[useSketchEvents] Failed to parse SSE event:', error, e.data)
-      }
-    }
-
-    eventSource.onerror = (error) => {
-      console.error('[useSketchEvents] EventSource error:', error)
-      eventSource.close()
-    }
+      },
+      onerror(err) {
+        console.error('[useSketchEvents] EventSource error:', err)
+        // Rethrow to stop automatic retrying
+        throw err
+      },
+    })
 
     return () => {
-      eventSource.close()
+      controller.abort()
     }
   }, [sketch_id, token])
 
@@ -78,8 +82,6 @@ export function useEvents(sketch_id: string | undefined) {
 
   return {
     logs,
-    // graphUpdates,
-    refetch: handleRefresh
-    // clearGraphUpdates: () => setGraphUpdates([]),
+    refetch: handleRefresh,
   }
 }

--- a/flowsint-app/src/hooks/use-graph-refresh.ts
+++ b/flowsint-app/src/hooks/use-graph-refresh.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import { fetchEventSource } from '@microsoft/fetch-event-source'
 import { useGraphControls } from '@/stores/graph-controls-store'
 import { useAuthStore } from '@/stores/auth-store'
 import { EventLevel } from '@/types'
@@ -25,55 +26,66 @@ export function useGraphRefresh(sketch_id: string | undefined) {
 
   useEffect(() => {
     if (!sketch_id || !token) return
-    const eventSource = new EventSource(
-      `${API_URL}/api/events/sketch/${sketch_id}/status/stream?token=${token}`
-    )
-    eventSource.onmessage = (e) => {
-      try {
-        // Handle malformed SSE data (connection message has extra "data: " prefix)
-        let dataStr = e.data
-        if (dataStr.startsWith('data: ')) {
-          dataStr = dataStr.substring(6) // Remove "data: " prefix
-        }
-        const raw = JSON.parse(dataStr) as any
-        // Ignore connection messages
-        if (raw.event === 'connected') {
-          return
-        }
-        // Only process status events
-        if (raw.event !== 'status') {
-          return
-        }
-        const event = JSON.parse(raw.data) as any
-        // Only handle COMPLETED events
-        if (event.type === EventLevel.COMPLETED) {
-          const refetch = refetchGraphRef.current
-          const regenerate = regenerateLayoutRef.current
-          const layoutType = currentLayoutTypeRef.current
 
-          if (typeof refetch !== 'function') {
+    const controller = new AbortController()
+
+    fetchEventSource(`${API_URL}/api/events/sketch/${sketch_id}/status/stream`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      signal: controller.signal,
+      onmessage(e) {
+        try {
+          // Handle malformed SSE data (connection message has extra "data: " prefix)
+          let dataStr = e.data
+          if (dataStr.startsWith('data: ')) {
+            dataStr = dataStr.substring(6) // Remove "data: " prefix
+          }
+
+          const raw = JSON.parse(dataStr) as any
+
+          // Ignore connection messages
+          if (raw.event === 'connected') {
             return
           }
 
-          // Refetch graph data with callback to regenerate layout after
-          refetch(() => {
-            // After refetch completes, regenerate layout if we have one active
-            if (layoutType && typeof regenerate === 'function') {
-              regenerate(layoutType)
-            }
-          })
-        }
-      } catch (error) {
-        console.error('[useGraphRefresh] Failed to parse SSE event:', error, e.data)
-      }
-    }
+          // Only process status events
+          if (raw.event !== 'status') {
+            return
+          }
 
-    eventSource.onerror = () => {
-      eventSource.close()
-    }
+          const event = JSON.parse(raw.data) as any
+
+          // Only handle COMPLETED events
+          if (event.type === EventLevel.COMPLETED) {
+            const refetch = refetchGraphRef.current
+            const regenerate = regenerateLayoutRef.current
+            const layoutType = currentLayoutTypeRef.current
+
+            if (typeof refetch !== 'function') {
+              return
+            }
+
+            // Refetch graph data with callback to regenerate layout after
+            refetch(() => {
+              // After refetch completes, regenerate layout if we have one active
+              if (layoutType && typeof regenerate === 'function') {
+                regenerate(layoutType)
+              }
+            })
+          }
+        } catch (error) {
+          console.error('[useGraphRefresh] Failed to parse SSE event:', error, e.data)
+        }
+      },
+      onerror() {
+        // Rethrow to stop automatic retrying
+        throw new Error('[useGraphRefresh] SSE connection error')
+      },
+    })
 
     return () => {
-      eventSource.close()
+      controller.abort()
     }
   }, [sketch_id, token]) // Only reconnect when sketch_id or token changes
 }


### PR DESCRIPTION
Fixes #145 (in the upstream repo: reconurge/flowsint#145)

## Problem
The native EventSource API doesn't support custom headers, so the auth 
token was being passed as a URL query parameter (?token=...). This exposes 
the token in server logs, browser history, and HTTP referrer headers.

## Solution
- Replaced `new EventSource()` with `fetchEventSource()` from 
  `@microsoft/fetch-event-source` in `use-events.ts` and `use-graph-refresh.ts`
- Token is now sent as `Authorization: Bearer <token>` header
- Removed the query param fallback from `get_current_user_sse` in `deps.py`