### PR TITLE
fix(import): preserve apostrophes in valid JSON imports

### DIFF
--- a/flowsint-core/src/flowsint_core/imports/json/parse_json.py
+++ b/flowsint-core/src/flowsint_core/imports/json/parse_json.py
@@ -23,8 +23,15 @@ def parse_json(
     try:
         file_bytes = file_bytes.lstrip()
         entities: Dict[str, Entity] = {}
-        my_bytes_value = file_bytes.decode().replace("'", '"')
-        graph = json.loads(my_bytes_value)
+        decoded = file_bytes.decode()
+        # Parse strict JSON first so apostrophes inside string values (e.g.
+        # "Sarah O'Brien") are preserved. Only fall back to the lenient
+        # single-quote replacement for Python-dict-style payloads that are not
+        # valid JSON on their own.
+        try:
+            graph = json.loads(decoded)
+        except json.JSONDecodeError:
+            graph = json.loads(decoded.replace("'", '"'))
         node_key = next((k for k in VALID_NODES_KEYS if k in graph), None)
         edge_key = next((k for k in VALID_EDGES_KEYS if k in graph), None)
         if node_key is None:

--- a/flowsint-core/tests/import/json/test_json_import.py
+++ b/flowsint-core/tests/import/json/test_json_import.py
@@ -65,3 +65,40 @@ def test_standard_json_import_without_label():
     """Test basic standard JSON import."""
     results = parse_json(standard_json_without_label, max_preview_rows=100)
     assert "Username" in results.entities
+
+
+# Valid JSON whose string values contain apostrophes (very common in OSINT
+# data, e.g. surnames like "O'Brien"). This is well-formed JSON and must import.
+json_with_apostrophe = b"""{
+  "nodes": [
+    {"id": "1", "label": "Sarah O'Brien", "type": "individual"},
+    {"id": "2", "label": "Bob", "type": "individual"}
+  ],
+  "edges": [
+    {"source": "1", "target": "2", "label": "KNOWS"}
+  ]
+}"""
+
+
+def test_json_import_preserves_apostrophes_in_string_values():
+    """Valid JSON with an apostrophe in a value must parse and keep the value.
+
+    Regression: the parser used to blindly replace every single quote with a
+    double quote, which corrupted valid JSON (turning "Sarah O'Brien" into
+    "Sarah O"Brien") and raised "Invalid JSON".
+    """
+    results = parse_json(json_with_apostrophe, max_preview_rows=100)
+
+    assert "Individual" in results.entities
+    labels = {
+        str(preview.obj.nodeLabel)
+        for preview in results.entities["Individual"].results
+    }
+    assert "Sarah O'Brien" in labels
+
+
+def test_json_import_still_accepts_single_quoted_payload():
+    """Python-dict-style payloads (single-quoted) remain supported as fallback."""
+    single_quoted = b"{'nodes': [{'id': '1', 'label': 'Alice', 'type': 'individual'}], 'edges': []}"
+    results = parse_json(single_quoted, max_preview_rows=100)
+    assert "Individual" in results.entities


### PR DESCRIPTION
## Bug

`parse_json` (`flowsint-core/src/flowsint_core/imports/json/parse_json.py`) unconditionally rewrote the file before parsing:

```python
my_bytes_value = file_bytes.decode().replace("'", '"')
graph = json.loads(my_bytes_value)
```

Replacing **every** single quote with a double quote corrupts any *valid* JSON string value that contains an apostrophe — extremely common in OSINT data (names, org names, free-text). For example a node label `"Sarah O'Brien"` becomes `"Sarah O"Brien"`, which is no longer valid JSON, so `json.loads` raises and the whole import is rejected with `Invalid JSON: Expecting ',' delimiter ...`.

## Reproduction

```python
from flowsint_core.imports.json.parse_json import parse_json

data = b'''{
  "nodes": [
    {"id": "1", "label": "Sarah O'Brien", "type": "individual"},
    {"id": "2", "label": "Bob", "type": "individual"}
  ],
  "edges": [{"source": "1", "target": "2", "label": "KNOWS"}]
}'''

parse_json(data, max_preview_rows=100)
# Before: Exception: Invalid JSON: Expecting ',' delimiter: line ... (char 41)
# After:  parses OK; the "Sarah O'Brien" label is preserved
```

This is well-formed JSON — it should always import.

## Fix

Parse strict JSON first (handles all valid JSON, apostrophes included). Only if that fails, fall back to the original lenient single-quote→double-quote replacement, preserving support for Python-dict-style payloads that aren't valid JSON on their own. Minimal, surgical change confined to the decode/parse step.

## Regression tests

Added to `tests/import/json/test_json_import.py`:
- `test_json_import_preserves_apostrophes_in_string_values` — **fails before** this change (raises `Invalid JSON`), **passes after**.
- `test_json_import_still_accepts_single_quoted_payload` — confirms the single-quoted fallback still works.

Full `tests/import/` suite: **46 passed** (44 pre-existing + 2 new) on Python 3.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)