### PR TITLE
fix(ssrf): block numeric-encoded IPv4 loopback/private addresses

### DIFF
--- a/flowsint-core/src/flowsint_core/templates/loader/yaml_loader.py
+++ b/flowsint-core/src/flowsint_core/templates/loader/yaml_loader.py
@@ -1,5 +1,6 @@
 import ipaddress
 import re
+import socket
 from typing import Any, Optional, Set
 from urllib.parse import urlparse
 
@@ -53,17 +54,36 @@ class TemplateRenderError(Exception):
     pass
 
 
+def _normalize_ip(ip_str: str) -> Optional[ipaddress._BaseAddress]:
+    """Resolve a host literal to an IP address, including legacy numeric forms.
+
+    ``ipaddress.ip_address`` only accepts canonical notations, but HTTP
+    clients and the OS resolver also accept decimal ("2130706433"), hex
+    ("0x7f000001"), octal ("017700000001") and short ("127.1") IPv4 forms.
+    Those all resolve to 127.0.0.1, so they must be canonicalized before the
+    blocklist check or they bypass SSRF protection.
+    """
+    try:
+        return ipaddress.ip_address(ip_str)
+    except ValueError:
+        pass
+    try:
+        # inet_aton accepts the same legacy IPv4 forms as the C resolver.
+        return ipaddress.ip_address(socket.inet_aton(ip_str))
+    except (OSError, ValueError):
+        return None
+
+
 def is_ip_blocked(ip_str: str) -> bool:
     """Check if an IP address is in a blocked range."""
-    try:
-        ip = ipaddress.ip_address(ip_str)
-        for blocked_range in BLOCKED_IP_RANGES:
-            if ip in blocked_range:
-                return True
-        return False
-    except ValueError:
+    ip = _normalize_ip(ip_str)
+    if ip is None:
         # Not a valid IP address
         return False
+    for blocked_range in BLOCKED_IP_RANGES:
+        if ip in blocked_range:
+            return True
+    return False
 
 
 def validate_url_safe(url: str) -> None:

--- a/flowsint-core/src/flowsint_core/templates/loader/yaml_loader.py
+++ b/flowsint-core/src/flowsint_core/templates/loader/yaml_loader.py
@@ -1,5 +1,6 @@
 import ipaddress
 import re
+import socket
 from typing import Any, Dict, Optional, Set
 from urllib.parse import urlparse
 
@@ -49,17 +50,36 @@ class TemplateRenderError(Exception):
     """Raised when template rendering fails."""
 
 
+def _normalize_ip(ip_str: str) -> Optional[ipaddress._BaseAddress]:
+    """Resolve a host literal to an IP address, including legacy numeric forms.
+
+    ``ipaddress.ip_address`` only accepts canonical notations, but HTTP
+    clients and the OS resolver also accept decimal ("2130706433"), hex
+    ("0x7f000001"), octal ("017700000001") and short ("127.1") IPv4 forms.
+    Those all resolve to 127.0.0.1, so they must be canonicalized before the
+    blocklist check or they bypass SSRF protection.
+    """
+    try:
+        return ipaddress.ip_address(ip_str)
+    except ValueError:
+        pass
+    try:
+        # inet_aton accepts the same legacy IPv4 forms as the C resolver.
+        return ipaddress.ip_address(socket.inet_aton(ip_str))
+    except (OSError, ValueError):
+        return None
+
+
 def is_ip_blocked(ip_str: str) -> bool:
     """Check if an IP address is in a blocked range."""
-    try:
-        ip = ipaddress.ip_address(ip_str)
-        for blocked_range in BLOCKED_IP_RANGES:
-            if ip in blocked_range:
-                return True
-        return False
-    except ValueError:
+    ip = _normalize_ip(ip_str)
+    if ip is None:
         # Not a valid IP address
         return False
+    for blocked_range in BLOCKED_IP_RANGES:
+        if ip in blocked_range:
+            return True
+    return False
 
 
 def validate_url_safe(url: str) -> None:

--- a/flowsint-core/tests/templates/test_loader.py
+++ b/flowsint-core/tests/templates/test_loader.py
@@ -248,6 +248,36 @@ class TestSSRFProtection:
         with pytest.raises(SSRFError):
             validate_url_safe("http://metadata.google.internal/")
 
+    def test_is_ip_blocked_numeric_loopback_encodings(self):
+        """Legacy numeric IPv4 encodings of loopback must be blocked.
+
+        HTTP clients and the OS resolver accept decimal/hex/octal/short forms
+        of 127.0.0.1; they previously slipped past the blocklist because
+        ipaddress.ip_address rejects them.
+        """
+        assert is_ip_blocked("2130706433") is True  # decimal 127.0.0.1
+        assert is_ip_blocked("0x7f000001") is True  # hex 127.0.0.1
+        assert is_ip_blocked("017700000001") is True  # octal 127.0.0.1
+        assert is_ip_blocked("127.1") is True  # short form 127.0.0.1
+        assert is_ip_blocked("0") is True  # 0.0.0.0 (current network)
+
+    def test_is_ip_blocked_numeric_public_still_allowed(self):
+        """A numeric encoding of a public IP must not be falsely blocked."""
+        assert is_ip_blocked("0x08080808") is False  # hex 8.8.8.8
+
+    def test_validate_url_safe_numeric_ip_bypass(self):
+        """SSRF protection must block numeric-encoded loopback/metadata URLs."""
+        with pytest.raises(SSRFError):
+            validate_url_safe("http://2130706433/")  # 127.0.0.1
+        with pytest.raises(SSRFError):
+            validate_url_safe("http://0x7f000001/")  # 127.0.0.1
+        with pytest.raises(SSRFError):
+            validate_url_safe("http://017700000001/")  # 127.0.0.1
+        with pytest.raises(SSRFError):
+            validate_url_safe("http://127.1/")  # short form 127.0.0.1
+        # Legitimate public host expressed numerically still passes.
+        validate_url_safe("http://0x08080808/")  # 8.8.8.8
+
     def test_validate_url_safe_file_scheme(self):
         """File scheme should be blocked."""
         with pytest.raises(SSRFError):


### PR DESCRIPTION
## Bug (security — SSRF bypass)

`flowsint-core/src/flowsint_core/templates/loader/yaml_loader.py` protects outbound enricher requests against SSRF via `validate_url_safe` → `is_ip_blocked`. `is_ip_blocked` canonicalizes the host with `ipaddress.ip_address`, which accepts **only** the dotted-quad IPv4 form.

However, `httpx` (used by `TemplateEnricher`) and the OS resolver also accept legacy numeric IPv4 encodings that all resolve to `127.0.0.1`:

- decimal: `2130706433`
- hex: `0x7f000001`
- octal: `017700000001`
- short form: `127.1`

`ipaddress.ip_address` rejects all of these, so `is_ip_blocked` returned `False` and the URL was reported **ALLOWED** — bypassing the loopback/private/metadata blocklist. A template URL like `http://2130706433/` therefore reaches internal services.

`validate_url_safe` is reached on the real request path: `template_enricher.py` renders a template URL and calls `validate_url_safe(url)` immediately before the `httpx` request.

## Reproduction

```python
from flowsint_core.templates.loader.yaml_loader import validate_url_safe, is_ip_blocked

is_ip_blocked("2130706433")          # before: False   (after: True)
validate_url_safe("http://2130706433/")  # before: returns (ALLOWED); after: raises SSRFError
```

End-to-end confirmation against a loopback listener: `httpx.get("http://2130706433:<port>/")` and `httpx.get("http://0x7f000001:<port>/")` both connect to `127.0.0.1` and return the internal response, while `validate_url_safe` (pre-fix) raised nothing.

## Fix

Normalize the host literal through `socket.inet_aton` (which mirrors the C resolver's acceptance of decimal/hex/octal/short IPv4 forms) before the blocklist check. All numeric encodings of a blocked address are now caught; numeric encodings of public addresses (e.g. `0x08080808` → `8.8.8.8`) remain allowed. Change is confined to `is_ip_blocked` plus a small `_normalize_ip` helper.

## Regression tests

Added to the existing `TestSSRFProtection` class in `tests/templates/test_loader.py`:
- `test_is_ip_blocked_numeric_loopback_encodings` and `test_validate_url_safe_numeric_ip_bypass` — **fail before** this change (numeric forms reported as not-blocked / ALLOWED), **pass after**.
- `test_is_ip_blocked_numeric_public_still_allowed` — guards against false positives on a public numeric address.

`tests/templates/test_loader.py`: **43 passed** on Python 3.12. (Pre-existing, unrelated failures/errors in `tests/templates/test_template_enricher.py` exist on `main` independently of this change and are untouched by it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)