### PR TITLE
fix: use aware UTC in auth and log cutoffs

### DIFF
--- a/flowsint-api/tests/test_events_auth.py
+++ b/flowsint-api/tests/test_events_auth.py
@@ -1,9 +1,12 @@
 """Auth and shape contract for the SSE event endpoints."""
 
 import importlib
+from datetime import datetime, timezone
 
 import pytest
+from jose import jwt
 
+from flowsint_core.core import auth
 from flowsint_core.core.auth import create_access_token
 from flowsint_core.core.models import Profile
 
@@ -48,3 +51,23 @@ def test_get_current_user_accepts_valid_bearer(db_session):
     token = create_access_token({"sub": "user@example.com"})
     user = get_current_user(token=token, db=db_session)
     assert user.email == "user@example.com"
+
+
+def test_create_access_token_uses_timezone_aware_expiration(monkeypatch):
+    class Clock:
+        @staticmethod
+        def now(tz=None):
+            assert tz == timezone.utc
+            return datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+        @staticmethod
+        def utcnow():
+            raise AssertionError("create_access_token should not use datetime.utcnow()")
+
+    monkeypatch.setattr(auth, "datetime", Clock)
+
+    token = create_access_token({"sub": "user@example.com"})
+
+    decoded = jwt.decode(token, auth.AUTH_SECRET, algorithms=[auth.ALGORITHM])
+
+    assert decoded["sub"] == "user@example.com"

--- a/flowsint-core/src/flowsint_core/core/auth.py
+++ b/flowsint-core/src/flowsint_core/core/auth.py
@@ -1,5 +1,5 @@
 from passlib.context import CryptContext
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from jose import jwt
 import os
 from dotenv import load_dotenv
@@ -29,7 +29,7 @@ def get_password_hash(password: str) -> str:
 
 def create_access_token(data: dict, expires_delta: timedelta | None = None):
     to_encode = data.copy()
-    expire = datetime.utcnow() + (
+    expire = datetime.now(timezone.utc) + (
         expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     )
     to_encode.update({"exp": expire})

--- a/flowsint-core/src/flowsint_core/core/repositories/log_repository.py
+++ b/flowsint-core/src/flowsint_core/core/repositories/log_repository.py
@@ -1,5 +1,5 @@
 """Repository for Log model."""
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 from uuid import UUID
 
@@ -26,7 +26,7 @@ class LogRepository(BaseRepository[Log]):
             query = query.filter(Log.created_at > since)
         else:
             query = query.filter(
-                Log.created_at > datetime.utcnow() - timedelta(days=1)
+                Log.created_at > datetime.now(timezone.utc) - timedelta(days=1)
             )
 
         return query.limit(limit).all()

--- a/flowsint-core/tests/repositories/test_log_repository.py
+++ b/flowsint-core/tests/repositories/test_log_repository.py
@@ -59,3 +59,20 @@ class TestLogRepository:
         repo = LogRepository(db_session)
         results = repo.get_by_sketch(uuid4(), since=datetime(2000, 1, 1))
         assert len(results) == 0
+
+    def test_get_by_sketch_defaults_to_recent_aware_utc_cutoff(self, db_session):
+        self._setup(db_session)
+        sketch = SketchFactory()
+        LogFactory(
+            sketch_id=sketch.id,
+            created_at=datetime.now(timezone.utc) - timedelta(hours=2),
+        )
+        LogFactory(
+            sketch_id=sketch.id,
+            created_at=datetime.now(timezone.utc) - timedelta(days=2),
+        )
+
+        repo = LogRepository(db_session)
+        results = repo.get_by_sketch(sketch.id)
+
+        assert len(results) == 1


### PR DESCRIPTION
## What changed

This replaces the remaining naive UTC timestamp calls in core auth/log paths with timezone-aware UTC timestamps:

- `create_access_token()` now builds JWT expiration with `datetime.now(timezone.utc)`
- `LogRepository.get_by_sketch()` now uses a timezone-aware default cutoff for the last 24 hours
- added focused coverage for the token clock call and the default recent-log filter

## Problem

These two paths still used `datetime.utcnow()`, while nearby service timestamps had already moved to aware UTC values. Keeping these call sites naive can make comparisons and future Python compatibility more brittle.

## Before / after

Before:
- token expiration and default log cutoff used naive UTC datetimes
- tests did not guard these remaining core paths

After:
- both paths use explicit `timezone.utc`
- token test fails if the implementation falls back to `datetime.utcnow()`
- log repository test covers the default cutoff behavior with aware timestamps

## Verification

- `python -m py_compile flowsint-core\src\flowsint_core\core\auth.py flowsint-core\src\flowsint_core\core\repositories\log_repository.py flowsint-api\tests\test_events_auth.py flowsint-core\tests\repositories\test_log_repository.py`

I also tried:

- `PYTHONPATH=flowsint-core\src;flowsint-api python -m pytest flowsint-api\tests\test_events_auth.py flowsint-core\tests\repositories\test_log_repository.py`

but local collection is blocked in this environment by missing `passlib` before the tests run (`ModuleNotFoundError: No module named 'passlib'`).