### PR TITLE
fix(security): Host-header allowlist + restore dropped security headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Anyone on the network can then access Flowsint at `http://<server-ip>:5173`.
 - `MASTER_VAULT_KEY_V1` — encrypts stored API keys. Generate one: `python3 -c "import os, base64; print('base64:' + base64.b64encode(os.urandom(32)).decode())"`
 - `NEO4J_PASSWORD` — Neo4j database password.
 
+**Also add your server hostname/IP to the Host-header allowlist** in `flowsint-app/nginx.conf` (look for `map $http_host $is_flowsint_host`). The default allowlist accepts only `localhost` / `127.0.0.1` / `[::1]`, which defends single-user installs against DNS rebinding; LAN and public deploys must opt-in their own hostname. Two commented-out template lines in the same map block show the format.
+
 Only port `5173` is exposed to the network. PostgreSQL, Redis, Neo4j and the API are bound to `127.0.0.1` on the server and reachable only through the frontend proxy.
 
 To pin a specific version instead of `latest`, set `FLOWSINT_VERSION` in `.env` (e.g. `FLOWSINT_VERSION=1.2.10`).

--- a/flowsint-app/nginx.conf
+++ b/flowsint-app/nginx.conf
@@ -45,11 +45,38 @@ http {
     # Security
     server_tokens off;
 
+    # Host-header allowlist — defends against DNS rebinding.
+    # The CORSMiddleware on the API blocks cross-origin reads, but after a
+    # DNS rebinding flip the browser treats the request as same-origin and
+    # skips the CORS check entirely, so a server-side Host check is the
+    # canonical defense. Without it, attacker JS on evil.com can drive a
+    # victim's browser to POST /api/auth/register against a flowsint instance
+    # bound to localhost or a LAN IP, planting attacker-controlled accounts.
+    #
+    # Default allowlist covers single-user local deploys (localhost / 127.0.0.1
+    # / ::1, any port). When deploying on a network (see README "Deploy on a
+    # network"), add the server hostname/IP below — and add the public
+    # hostname too when fronting with a reverse proxy like Caddy.
+    map $http_host $is_flowsint_host {
+        default 0;
+        "~*^localhost(:[0-9]+)?$"    1;
+        "~*^127\.0\.0\.1(:[0-9]+)?$" 1;
+        "~*^\[::1\](:[0-9]+)?$"      1;
+        # "~*^flowsint\.example\.com$"   1;
+        # "~*^192\.168\.1\.42(:[0-9]+)?$" 1;
+    }
+
     server {
         listen 8080;
         server_name _;
         root /usr/share/nginx/html;
         index index.html;
+
+        # Default-deny unknown Host headers (DNS rebinding defense).
+        # See $is_flowsint_host map above for the allowlist.
+        if ($is_flowsint_host = 0) {
+            return 403;
+        }
 
         # Security headers
         add_header X-Frame-Options "SAMEORIGIN" always;
@@ -88,6 +115,13 @@ http {
         location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
             expires 1y;
             add_header Cache-Control "public, immutable";
+            # Re-declare server-level security headers — nginx's add_header
+            # inheritance is replace-all, not merge, so a location block that
+            # sets any add_header drops every header set higher up.
+            add_header X-Frame-Options "SAMEORIGIN" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header X-XSS-Protection "1; mode=block" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
             access_log off;
         }
 
@@ -100,6 +134,12 @@ http {
         location = /index.html {
             expires -1;
             add_header Cache-Control "no-store, no-cache, must-revalidate";
+            # Re-declare server-level security headers (see static-assets
+            # location above for why).
+            add_header X-Frame-Options "SAMEORIGIN" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header X-XSS-Protection "1; mode=block" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         }
 
         # Deny access to hidden files


### PR DESCRIPTION
## Summary

Adds a Host-header allowlist to `flowsint-app/nginx.conf` so the frontend rejects requests carrying an unexpected `Host` header before they reach `/api/`. Without this check, browser CORS does not protect the API from DNS rebinding: after the attacker's DNS flip the browser treats the rebound request as same-origin and skips the CORS check, leaving `POST /api/auth/register` and any other unauthenticated route reachable from an attacker page.

Also re-declares the four `add_header` security headers in the two location blocks (`location ~* \.(js|css|...)$` and `location = /index.html`) that were silently dropping them. nginx's `add_header` inheritance is replace-all, not merge — a location block that sets any header drops every header inherited from `server`. The main HTML page was shipping without `X-Frame-Options`, `X-Content-Type-Options`, `X-XSS-Protection`, or `Referrer-Policy`.

## Impact

**DNS rebinding (primary).** Attacker JS on `evil.com` makes `evil.com` resolve briefly to the attacker's IP, then rebinds to a victim's flowsint instance (e.g. `127.0.0.1`). Browser sends `Host: evil.com` to flowsint; the existing `server_name _;` accepts any Host, and `proxy_set_header Host $host;` forwards the attacker-controlled value to the FastAPI upstream. The CORS middleware in `flowsint-api/app/main.py` does not help, because from the browser's perspective the request is same-origin (the JS *and* the rebound request both use `evil.com`).

Concrete reachable surface from an attacker page, today, with the default deploy:

- `POST /api/auth/register` — open registration. Attacker can plant accounts in the victim's instance. The first registration on a fresh deploy becomes the de-facto admin.
- `POST /api/auth/token` — login. Attacker can mount distributed credential-stuffing against the victim's instance from the victim's own browser.
- `GET /health` — info leak (low).

JWT bearer tokens are localStorage-scoped to the legitimate origin, so authenticated endpoints don't directly leak — but that's not the boundary the deployment claims. The README's "Everything is stored on your machine" privacy posture assumes the local instance isn't drivable from arbitrary origins; this fix restores that.

**Dropped security headers (secondary).** With the prior config, hitting `/` (the SPA) returns `/index.html` from the `location = /index.html` block, which sets `add_header Cache-Control "no-store, ..."` and thereby drops every server-level security header. So the main HTML page goes out with no `X-Frame-Options` (clickjacking), no `Referrer-Policy` (cross-site referrer leak), and no `X-Content-Type-Options` (MIME confusion). Same loss applied to the static-assets location for `.js`/`.css`.

## Location

- `flowsint-app/nginx.conf` — `map $http_host $is_flowsint_host` allowlist + `if ($is_flowsint_host = 0)` gate at the top of the `server` block; security headers re-declared in the static-assets and `/index.html` locations.
- `README.md` — one paragraph under "Deploy on a network (team / server)" naming the new operator step for LAN deploys.

## Fix

- New `map $http_host $is_flowsint_host` block at `http` level. Default `0`; allowlist entries for `localhost`, `127.0.0.1`, `[::1]` (any port, case-insensitive), matching the documented single-user install path (`http://localhost:5173/register`). Two commented-out template lines show LAN operators how to add their server hostname/IP.
- New `if ($is_flowsint_host = 0) { return 403; }` at the top of the `server` block, before any header or location processing.
- In `location ~* \.(js|css|...)$` and `location = /index.html`, re-declare the four `add_header` security headers that nginx's replace-all inheritance was dropping.
- README: one paragraph under "Deploy on a network" telling operators to add their hostname/IP to the allowlist alongside the existing `.env` secret rotation step.

## Verification

- `nginx -t -c flowsint-app/nginx.conf -p <prefix>/` → `syntax is ok` / `test is successful`.
- 26/26 Host-header regression cases pass (allowed: `localhost`, `localhost:5173`, `127.0.0.1`, `LocalHost:5173`, `[::1]`, `[::1]:5173`, etc.; blocked: `evil.com`, `evil.com:5173`, `localhost.evil.com`, `127.0.0.1.attacker.com`, `127-0-0-1.attacker.com`, `127.0.0.1evil`, empty host, `192.168.1.42` (operator must opt-in), AWS-metadata IP, etc.).
- LAN-deploy regression: `192.168.1.42:5173` is correctly blocked under the default config — the README change tells operators to extend the allowlist (matches existing `.env`-rotation pattern).
- Static assets (`.js`/`.css`) and `/index.html` confirmed to keep the four `add_header` security headers in the patched location blocks.

## Detected by

Aeon + semgrep
- Severity: medium
- CWE-350 (Reliance on Reverse DNS Resolution for a Security-Critical Action) / CWE-352 (CSRF, the rebinding variant) / CWE-1021 (Improper Restriction of Rendered UI Layers — for the missing X-Frame-Options on `/index.html`).
- semgrep rule: `generic.nginx.security.request-host-used` at `flowsint-app/nginx.conf:69` flagged the unvalidated `Host` propagation; `generic.nginx.security.header-redefinition` at `:84`/`:90`/`:102` flagged the silently dropped headers.

---
Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).
