### PR TITLE
feat(imports): add nmap XML importer

### DIFF
--- a/flowsint-api/app/api/routes/sketches.py
+++ b/flowsint-api/app/api/routes/sketches.py
@@ -420,10 +420,12 @@ async def analyze_import_file(
     except PermissionDeniedError:
         raise HTTPException(status_code=403, detail="Forbidden")
 
-    if not file.filename or not file.filename.lower().endswith((".txt", ".json")):
+    if not file.filename or not file.filename.lower().endswith(
+        (".txt", ".json", ".xml")
+    ):
         raise HTTPException(
             status_code=400,
-            detail="Only .txt and .json files are supported. Please upload a correct format.",
+            detail="Only .txt, .json and .xml files are supported. Please upload a correct format.",
         )
 
     try:

--- a/flowsint-app/src/components/sketches/import-sheet.tsx
+++ b/flowsint-app/src/components/sketches/import-sheet.tsx
@@ -19,7 +19,7 @@ interface ImportSheetProps {
   sketchId: string
 }
 
-const ALLOWED_EXTENSIONS = ['.txt', '.json']
+const ALLOWED_EXTENSIONS = ['.txt', '.json', '.xml']
 
 export function ImportSheet({ sketchId }: ImportSheetProps) {
   const onOpenChange = useGraphSettingsStore((s) => s.setImportModalOpen)

--- a/flowsint-core/pyproject.toml
+++ b/flowsint-core/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "pytest>=8.4.2,<9.0.0",
     "cryptography>=45.0.7,<46.0.0",
     "openpyxl>=3.1,<4.0",
+    "defusedxml>=0.7,<0.8",
 ]
 
 [dependency-groups]

--- a/flowsint-core/src/flowsint_core/imports/file_parser.py
+++ b/flowsint-core/src/flowsint_core/imports/file_parser.py
@@ -10,10 +10,11 @@ from typing import BinaryIO, Optional, Union
 from flowsint_core.core.graph.serializer import TypeResolver
 
 from .json import parse_json
+from .nmap import parse_nmap_xml
 from .txt import parse_txt
 from .types import FileParseResult
 
-ALLOWED_EXTENSIONS = [".txt", ".json"]
+ALLOWED_EXTENSIONS = [".txt", ".json", ".xml"]
 
 
 def parse_import_file(
@@ -44,3 +45,5 @@ def parse_import_file(
         return parse_txt(file_bytes, max_preview_rows)
     elif file_ext in [".json"]:
         return parse_json(file_bytes, max_preview_rows, type_resolver=type_resolver)
+    elif file_ext == ".xml":
+        return parse_nmap_xml(file_bytes, max_preview_rows, type_resolver=type_resolver)

--- a/flowsint-core/src/flowsint_core/imports/nmap/__init__.py
+++ b/flowsint-core/src/flowsint_core/imports/nmap/__init__.py
@@ -1,0 +1,3 @@
+from .parse_nmap import parse_nmap_xml
+
+__all__ = ["parse_nmap_xml"]

--- a/flowsint-core/src/flowsint_core/imports/nmap/parse_nmap.py
+++ b/flowsint-core/src/flowsint_core/imports/nmap/parse_nmap.py
@@ -1,0 +1,150 @@
+"""Parser for nmap XML scan output.
+
+Turns an nmap (or naabu --json -nmap-cli style) XML report into Ip and Port
+entities plus IP-[HAS_PORT]->Port edges, so an existing scan can be imported
+into a sketch without re-scanning the target (issue #107).
+"""
+
+import xml.etree.ElementTree as ET
+from typing import Dict, List, Optional
+
+# defusedxml hardens parsing against XXE / billion-laughs attacks; import files
+# are untrusted input. Element type hints still come from the stdlib (the types
+# are identical and not a security concern).
+from defusedxml.ElementTree import fromstring as safe_fromstring
+
+from flowsint_types import Ip, Port
+
+from flowsint_core.core.graph.serializer import TypeResolver
+
+from ..types import Edge, Entity, EntityPreview, FileParseResult
+
+
+def _host_address(host: ET.Element) -> Optional[str]:
+    """Return the host's IP address, preferring IPv4 then IPv6."""
+    for addrtype in ("ipv4", "ipv6"):
+        el = host.find(f"./address[@addrtype='{addrtype}']")
+        if el is not None and el.get("addr"):
+            return el.get("addr")
+    # Fallback: first address element that isn't a MAC.
+    for el in host.findall("address"):
+        if el.get("addrtype") != "mac" and el.get("addr"):
+            return el.get("addr")
+    return None
+
+
+def _is_host_up(host: ET.Element) -> bool:
+    status = host.find("status")
+    # Treat missing status as up (some tools omit it); only skip explicit "down".
+    return status is None or status.get("state") != "down"
+
+
+def _build_port(port_el: ET.Element) -> Optional[Port]:
+    portid = port_el.get("portid")
+    if not portid:
+        return None
+    try:
+        number = int(portid)
+    except (TypeError, ValueError):
+        return None
+
+    protocol = (port_el.get("protocol") or "").upper() or None
+
+    state_el = port_el.find("state")
+    state = state_el.get("state") if state_el is not None else None
+
+    service_el = port_el.find("service")
+    service = None
+    banner = None
+    if service_el is not None:
+        service = service_el.get("name") or None
+        # Compose a human-readable banner from product/version/extrainfo.
+        banner = " ".join(
+            part
+            for part in (
+                service_el.get("product"),
+                service_el.get("version"),
+                service_el.get("extrainfo"),
+            )
+            if part
+        ) or None
+
+    try:
+        return Port(
+            number=number,
+            protocol=protocol,
+            state=state,
+            service=service,
+            banner=banner,
+        )
+    except Exception:
+        # Out-of-range port number or other validation failure: skip it.
+        return None
+
+
+def parse_nmap_xml(
+    file_bytes: bytes,
+    max_preview_rows: int,
+    type_resolver: Optional[TypeResolver] = None,  # accepted for signature parity
+) -> FileParseResult:
+    """Parse nmap XML into Ip + Port entities and IP-[HAS_PORT]->Port edges."""
+    try:
+        root = safe_fromstring(file_bytes)
+    except ET.ParseError as e:
+        raise ValueError(f"Invalid nmap XML file: {e}")
+
+    entities: Dict[str, Entity] = {}
+    edges: List[Edge] = []
+
+    def add_preview(preview: EntityPreview) -> None:
+        bucket = entities.get(preview.detected_type)
+        if bucket is None:
+            entities[preview.detected_type] = Entity(
+                type=preview.detected_type, results=[preview]
+            )
+        else:
+            bucket.results.append(preview)
+
+    for host in root.findall("host"):
+        if not _is_host_up(host):
+            continue
+
+        address = _host_address(host)
+        if not address:
+            continue
+
+        try:
+            ip_obj = Ip(address=address)
+        except Exception:
+            # Not a valid IP (shouldn't happen for nmap output) -> skip host.
+            continue
+
+        ip_node_id = f"ip-{address}"
+        ip_preview = EntityPreview(
+            node_id=ip_node_id, obj=ip_obj, detected_type="Ip"
+        )
+        add_preview(ip_preview)
+
+        for port_el in host.findall("./ports/port"):
+            port_obj = _build_port(port_el)
+            if port_obj is None:
+                continue
+
+            port_node_id = f"port-{address}-{port_obj.number}-{port_obj.protocol}"
+            add_preview(
+                EntityPreview(
+                    node_id=port_node_id, obj=port_obj, detected_type="Port"
+                )
+            )
+            edges.append(
+                Edge(
+                    from_obj=ip_obj,
+                    from_id=ip_node_id,
+                    to_obj=port_obj,
+                    to_id=port_node_id,
+                    label="HAS_PORT",
+                )
+            )
+
+    total = sum(len(entity.results) for entity in entities.values())
+    return FileParseResult(entities=entities, edges=edges, total_entities=total)

--- a/flowsint-core/tests/import/nmap/test_nmap_import.py
+++ b/flowsint-core/tests/import/nmap/test_nmap_import.py
@@ -1,0 +1,140 @@
+"""Tests for the nmap XML importer."""
+
+import pytest
+
+from flowsint_core.imports.file_parser import parse_import_file
+from flowsint_core.imports.nmap.parse_nmap import parse_nmap_xml
+from flowsint_types import Ip, Port
+
+# A representative nmap -oX report: one host up with two open ports, one host down.
+NMAP_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<nmaprun scanner="nmap" args="nmap -oX">
+  <host>
+    <status state="up" reason="syn-ack"/>
+    <address addr="93.184.216.34" addrtype="ipv4"/>
+    <address addr="00:11:22:33:44:55" addrtype="mac"/>
+    <ports>
+      <port protocol="tcp" portid="80">
+        <state state="open" reason="syn-ack"/>
+        <service name="http" product="nginx" version="1.18.0" extrainfo="Ubuntu"/>
+      </port>
+      <port protocol="tcp" portid="443">
+        <state state="open"/>
+        <service name="https"/>
+      </port>
+    </ports>
+  </host>
+  <host>
+    <status state="down" reason="no-response"/>
+    <address addr="10.0.0.1" addrtype="ipv4"/>
+    <ports>
+      <port protocol="tcp" portid="22">
+        <state state="open"/>
+        <service name="ssh"/>
+      </port>
+    </ports>
+  </host>
+</nmaprun>"""
+
+
+def test_parses_ip_and_ports():
+    result = parse_nmap_xml(NMAP_XML, max_preview_rows=100)
+
+    assert "Ip" in result.entities
+    assert "Port" in result.entities
+
+    ips = [p.obj for p in result.entities["Ip"].results]
+    assert [ip.address for ip in ips] == ["93.184.216.34"]
+    assert all(isinstance(ip, Ip) for ip in ips)
+
+    ports = {p.obj.number: p.obj for p in result.entities["Port"].results}
+    assert set(ports) == {80, 443}
+    assert all(isinstance(p, Port) for p in ports.values())
+
+
+def test_port_fields_and_banner():
+    result = parse_nmap_xml(NMAP_XML, max_preview_rows=100)
+    ports = {p.obj.number: p.obj for p in result.entities["Port"].results}
+
+    http = ports[80]
+    assert http.protocol == "TCP"
+    assert http.state == "open"
+    assert http.service == "http"
+    assert http.banner == "nginx 1.18.0 Ubuntu"
+
+    https = ports[443]
+    assert https.service == "https"
+    assert https.banner is None  # no product/version -> no banner
+
+
+def test_has_port_edges_link_ip_to_ports():
+    result = parse_nmap_xml(NMAP_XML, max_preview_rows=100)
+
+    assert len(result.edges) == 2
+    assert all(edge.label == "HAS_PORT" for edge in result.edges)
+    assert all(edge.from_id == "ip-93.184.216.34" for edge in result.edges)
+    assert {edge.to_id for edge in result.edges} == {
+        "port-93.184.216.34-80-TCP",
+        "port-93.184.216.34-443-TCP",
+    }
+
+
+def test_down_host_is_skipped():
+    result = parse_nmap_xml(NMAP_XML, max_preview_rows=100)
+    ip_addresses = [p.obj.address for p in result.entities["Ip"].results]
+    assert "10.0.0.1" not in ip_addresses  # the down host is excluded
+
+
+def test_total_entities_count():
+    result = parse_nmap_xml(NMAP_XML, max_preview_rows=100)
+    assert result.total_entities == 3  # 1 IP + 2 ports
+
+
+def test_ipv6_host():
+    xml = b"""<nmaprun>
+      <host>
+        <status state="up"/>
+        <address addr="2606:2800:220:1:248:1893:25c8:1946" addrtype="ipv6"/>
+        <ports><port protocol="tcp" portid="443"><state state="open"/></port></ports>
+      </host>
+    </nmaprun>"""
+    result = parse_nmap_xml(xml, max_preview_rows=100)
+    ips = [p.obj.address for p in result.entities["Ip"].results]
+    assert ips == ["2606:2800:220:1:248:1893:25c8:1946"]
+
+
+def test_invalid_port_number_is_skipped():
+    xml = b"""<nmaprun>
+      <host>
+        <status state="up"/>
+        <address addr="1.2.3.4" addrtype="ipv4"/>
+        <ports>
+          <port protocol="tcp" portid="not-a-number"><state state="open"/></port>
+          <port protocol="tcp" portid="22"><state state="open"/></port>
+        </ports>
+      </host>
+    </nmaprun>"""
+    result = parse_nmap_xml(xml, max_preview_rows=100)
+    ports = [p.obj.number for p in result.entities["Port"].results]
+    assert ports == [22]
+
+
+def test_empty_scan_returns_no_entities():
+    xml = b"""<nmaprun></nmaprun>"""
+    result = parse_nmap_xml(xml, max_preview_rows=100)
+    assert result.entities == {}
+    assert result.edges == []
+    assert result.total_entities == 0
+
+
+def test_invalid_xml_raises_value_error():
+    with pytest.raises(ValueError):
+        parse_nmap_xml(b"<nmaprun><host>", max_preview_rows=100)
+
+
+def test_xml_dispatched_via_file_parser():
+    """.xml files route to the nmap parser through the shared dispatcher."""
+    result = parse_import_file(NMAP_XML, "scan.xml")
+    assert result is not None
+    assert "Ip" in result.entities
+    assert isinstance(result.entities["Ip"].results[0].obj, Ip)

--- a/uv.lock
+++ b/uv.lock
@@ -788,6 +788,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1169,6 +1178,7 @@ dependencies = [
     { name = "bcrypt" },
     { name = "celery" },
     { name = "cryptography" },
+    { name = "defusedxml" },
     { name = "docker" },
     { name = "flowsint-enrichers" },
     { name = "httpx" },
@@ -1207,6 +1217,7 @@ requires-dist = [
     { name = "bcrypt", specifier = ">=4.0.0,<5.0.0" },
     { name = "celery", specifier = ">=5.3,<6.0" },
     { name = "cryptography", specifier = ">=45.0.7,<46.0.0" },
+    { name = "defusedxml", specifier = ">=0.7,<0.8" },
     { name = "docker", specifier = ">=7.1.0,<8.0.0" },
     { name = "flowsint-enrichers", editable = "flowsint-enrichers" },
     { name = "httpx", specifier = ">=0.28,<0.29" },


### PR DESCRIPTION
## What

Adds an **nmap XML importer** so an existing scan can be imported into a sketch, instead of re-scanning a target or adding ports by hand.

Closes #107

## Why

From the issue: during assessments people often run nmap manually with specific flags, and naabu can also export in nmap XML. Letting Flowsint ingest that XML enriches a sketch with the hosts/ports already discovered. This reuses the existing two-phase import pipeline (analyze → execute) — no new infrastructure.

## How it plugs in

The import pipeline dispatches parsers by file extension (`flowsint_core/imports/file_parser.py`) and each parser is a function returning a `FileParseResult` of typed entities + edges, which the pipeline persists. The new parser follows that exact contract (same shape as the existing JSON parser).

- `flowsint_core/imports/nmap/parse_nmap.py` (new) — `parse_nmap_xml()` turns an nmap report into:
  - `Ip` entities (one per *up* host; down hosts skipped; IPv4 preferred, IPv6 supported, MAC ignored)
  - `Port` entities (`number`, `protocol`, `state`, `service`, and a `banner` composed from service `product`/`version`/`extrainfo`)
  - `IP -[HAS_PORT]-> Port` edges (the same relationship label the `ip_to_ports` enricher uses)
- Wiring: `.xml` added to `ALLOWED_EXTENSIONS` (core dispatcher) + the analyze route's filename validation (`flowsint-api/.../sketches.py`) + the import sheet's accepted extensions (`flowsint-app/.../import-sheet.tsx`). `Ip` and `Port` already exist, so no type changes were needed.

## Security

Import files are untrusted, so the XML is parsed with **`defusedxml`** (new `flowsint-core` dependency) to prevent XXE / billion-laughs attacks. Element type hints still come from the stdlib (identical types, not a parsing path).

## Testing

```
uv run --package flowsint-core pytest flowsint-core/tests/import/ -q
56 passed   # 10 new nmap tests + existing import suite, no regressions
```

New tests (pure-parse, no DB): IP/port extraction, port fields + banner composition, `HAS_PORT` edges, down-host skipping, IPv6, invalid-port skipping, empty/invalid XML handling, and dispatch through `parse_import_file`.

> Scope note: this maps the core of an nmap scan (hosts + ports + service info). NSE script output (which could map to the existing `Script` type) is intentionally left out to keep the PR focused; happy to add it as a follow-up if wanted.