### PR TITLE
fix: "exec /docker-entrypoint.sh: exec format error" in flowsint-app

### DIFF
--- a/flowsint-app/Dockerfile
+++ b/flowsint-app/Dockerfile
@@ -17,7 +17,7 @@ ENV VITE_API_URL=${VITE_API_URL}
 
 RUN yarn build
 
-FROM nginx:1.27-alpine AS production
+FROM nginx:1.29-alpine AS production
 
 LABEL org.opencontainers.image.source="https://github.com/reconurge/flowsint"
 LABEL org.opencontainers.image.description="Flowsint Frontend"


### PR DESCRIPTION
chore: update nginx base image to version 1.29-alpine