### PR TITLE
fix(ui): remove frontend debug console logs

### DIFF
--- a/flowsint-app/src/components/dashboard/investigation/sketches-section.tsx
+++ b/flowsint-app/src/components/dashboard/investigation/sketches-section.tsx
@@ -30,7 +30,7 @@ export function SketchesSection({ sketches, canCreate = true }: SketchesSectionP
       </div>
 
       {isEmpty ? (
-        canCreate ? <EmptySketches onAction={() => console.log("Create sketch")} /> : <div className="text-sm text-muted-foreground py-4">No sketches yet.</div>
+        canCreate ? <EmptySketches /> : <div className="text-sm text-muted-foreground py-4">No sketches yet.</div>
       ) : (
         <div style={{ containerType: 'inline-size' }}>
         <div className="grid grid-cols-1 cq-sm:grid-cols-2 cq-md:grid-cols-3 cq-lg:grid-cols-4 gap-3">

--- a/flowsint-app/src/components/flows/raw-material.tsx
+++ b/flowsint-app/src/components/flows/raw-material.tsx
@@ -19,8 +19,6 @@ export default function RawMaterial() {
   })
   const [searchTerm, setSearchTerm] = useState<string>('')
 
-  console.log(materials)
-
   const filteredEnrichers = useMemo(() => {
     if (!materials?.items) return {}
     const result: Record<string, Enricher[]> = {}

--- a/flowsint-app/src/components/templates/template-editor.tsx
+++ b/flowsint-app/src/components/templates/template-editor.tsx
@@ -260,7 +260,6 @@ export function TemplateEditor({ templateId, initialContent, importedYaml }: Tem
         duration: response.duration_ms,
         url: response.url
       })
-      console.log(response)
     } catch (error) {
       setTestResult({
         success: false,


### PR DESCRIPTION
## What changed
- Removed leftover frontend `console.log` calls from raw material loading and template testing flows.
- Stopped passing a placeholder click handler that only logged `Create sketch`; the button is already wrapped by `NewSketch`.

## Problem
A few shipped UI paths still wrote raw data or placeholder messages to the browser console. That can make local debugging noisier and may expose unnecessary API response details during normal app usage.

## Before / after
Before:
- Opening raw materials logged the fetched materials object.
- Running a template test logged the full response object.
- Clicking the empty sketches action emitted a placeholder console message before the real `NewSketch` wrapper handled creation.

After:
- These UI paths no longer emit debug-only console output.
- Sketch creation behavior remains delegated to the existing `NewSketch` wrapper.

## Verification
- `git diff --check` passes.
- `corepack yarn install --frozen-lockfile` completed successfully.
- `corepack yarn typecheck` is currently blocked by existing project-wide TypeScript errors unrelated to these files, including missing Tiptap modules and table/router typing errors.
- A targeted ESLint run is currently blocked because `.eslintrc.cjs` requires `@typescript-eslint/parser`, but that parser is not installed by the lockfile.
