### PR TITLE
fix: read YAML templates as UTF-8

### DIFF
--- a/flowsint-core/src/flowsint_core/templates/loader/yaml_loader.py
+++ b/flowsint-core/src/flowsint_core/templates/loader/yaml_loader.py
@@ -109,7 +109,7 @@ def sanitize_url_component(value: str) -> str:
 class YamlLoader:
     @staticmethod
     def load_enricher_yaml(filename: str) -> dict[str, Any] | yaml.YAMLError:
-        with open(filename) as stream:
+        with open(filename, encoding="utf-8") as stream:
             try:
                 return yaml.safe_load(stream)
             except yaml.YAMLError as exc:


### PR DESCRIPTION
## What changed

This updates the YAML template loader to open template files with an explicit `encoding="utf-8"`.

## Problem

`open(filename)` depends on the host system's default text encoding. On systems where the default encoding is not UTF-8, YAML templates containing non-ASCII text can fail to load or decode differently than intended.

## Before / after

Before: template loading used the platform default encoding.

After: template loading consistently reads YAML templates as UTF-8 across platforms.

## Verification

- `AUTH_SECRET=0123456789abcdef0123456789abcdef REDIS_URL=redis://localhost:6379/0 uv run pytest flowsint-core/tests/templates/test_loader.py` → 40 passed
- `uv run python -m compileall flowsint-core/src/flowsint_core/templates/loader/yaml_loader.py`
- `git diff --check`