### PR TITLE
fix: use aware timestamp for fraud score updates

### DIFF
--- a/flowsint-enrichers/src/flowsint_enrichers/ip/to_fraudscore.py
+++ b/flowsint-enrichers/src/flowsint_enrichers/ip/to_fraudscore.py
@@ -124,7 +124,13 @@ class IpToFraudScore(Enricher):
                         proxy_flags.append(label)
 
                 risk_profile = RiskProfile(
-                    entity_id=ip.address, entity_type="IP address", overall_risk_score=fraud_score, risk_level=fraud_risk, last_updated=datetime.datetime.utcnow().isoformat(), risk_factors=proxy_flags, source="Scamalytics"
+                    entity_id=ip.address,
+                    entity_type="IP address",
+                    overall_risk_score=fraud_score,
+                    risk_level=fraud_risk,
+                    last_updated=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                    risk_factors=proxy_flags,
+                    source="Scamalytics",
                 )
                 results.append(risk_profile)
                 self.ip_risk_mapping.append((ip, risk_profile))


### PR DESCRIPTION
Problem: the Scamalytics IP enricher used datetime.utcnow() when setting RiskProfile.last_updated. That helper is deprecated and returns a naive UTC timestamp.

Before / after: before, fraud score updates stored a naive UTC ISO string. After, the timestamp is produced with datetime.datetime.now(datetime.timezone.utc).isoformat(), preserving UTC while including explicit timezone information.

Verification: python -m py_compile flowsint-enrichers\src\flowsint_enrichers\ip\to_fraudscore.py