### PR TITLE
fix(core): use aware UTC timestamps

### DIFF
--- a/flowsint-core/src/flowsint_core/core/auth.py
+++ b/flowsint-core/src/flowsint_core/core/auth.py
@@ -1,5 +1,5 @@
 from passlib.context import CryptContext
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from jose import jwt
 import os
 from dotenv import load_dotenv
@@ -29,7 +29,7 @@ def get_password_hash(password: str) -> str:
 
 def create_access_token(data: dict, expires_delta: timedelta | None = None):
     to_encode = data.copy()
-    expire = datetime.utcnow() + (
+    expire = datetime.now(timezone.utc) + (
         expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     )
     to_encode.update({"exp": expire})

--- a/flowsint-core/src/flowsint_core/core/repositories/log_repository.py
+++ b/flowsint-core/src/flowsint_core/core/repositories/log_repository.py
@@ -1,5 +1,5 @@
 """Repository for Log model."""
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 from uuid import UUID
 
@@ -26,7 +26,7 @@ class LogRepository(BaseRepository[Log]):
             query = query.filter(Log.created_at > since)
         else:
             query = query.filter(
-                Log.created_at > datetime.utcnow() - timedelta(days=1)
+                Log.created_at > datetime.now(timezone.utc) - timedelta(days=1)
             )
 
         return query.limit(limit).all()


### PR DESCRIPTION
Problem: two core timestamp paths still used `datetime.utcnow()`: JWT expiration in `create_access_token()` and the default 24-hour cutoff in `LogRepository.get_by_sketch()`. The project already uses timezone-aware UTC timestamps in nearby core services and models.

Before / after: before, both paths produced naive UTC datetimes. After, they use `datetime.now(timezone.utc)`, matching the repo's timezone-aware timestamp style while preserving the same expiry duration and one-day log cutoff behavior.

Verification:
- `python -m py_compile flowsint-core\src\flowsint_core\core\auth.py flowsint-core\src\flowsint_core\core\repositories\log_repository.py`
- Tried `python -m pytest flowsint-core\tests\repositories\test_log_repository.py` with source paths configured, but this local environment is missing `passlib`, so the test run stops during import before executing tests.