### PR TITLE
fix(deploy): disable OpenSSL ARM crypto extensions to avoid SIGILL

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -80,6 +80,10 @@ services:
       - AUTH_SECRET=${AUTH_SECRET}
       - MASTER_VAULT_KEY_V1=${MASTER_VAULT_KEY_V1}
       - REDIS_URL=redis://redis:6379/0
+      # Works around a SIGILL in cryptography's Rust/OpenSSL extension caused by
+      # mis-detected AArch64 crypto-extension CPU flags under some ARM64
+      # hypervisors (e.g. Colima/Apple Virtualization Framework). No-op elsewhere.
+      - OPENSSL_armcap=0
     depends_on:
       postgres:
         condition: service_healthy
@@ -120,6 +124,7 @@ services:
       - REDIS_URL=redis://redis:6379/0
       - SKIP_MIGRATIONS=true
       - AUTH_SECRET=${AUTH_SECRET}
+      - OPENSSL_armcap=0
     healthcheck:
       # Celery has no HTTP server — Dockerfile's curl-based healthcheck always fails.
       # Use celery's own ping primitive instead.


### PR DESCRIPTION
## Summary
- `make prod` fails on Apple Silicon under Colima (Apple Virtualization Framework / `vz` backend): the `api` container crash-loops with `Illegal instruction (core dumped)` (SIGILL, exit 132) during `alembic upgrade head`, so `flowsint-api-prod` never becomes healthy and `make prod` aborts.
- Root cause: the guest kernel reports AArch64 crypto-extension HWCAP flags (AES/PMULL/SHA) that the hypervisor's vCPU doesn't actually support. `alembic upgrade head` → `flowsint_core` → `redis` → PyJWT → `cryptography.hazmat.bindings` loads cryptography's Rust/OpenSSL extension, whose runtime CPU-feature detection picks an accelerated codepath that then executes an unsupported instruction.
- Fix: set `OPENSSL_armcap=0` on the `api` and `celery` services to force OpenSSL's portable C fallback. This only affects OpenSSL's AArch64 codepath — it's a no-op on x86_64 and on hosts where the HWCAP flags are reported correctly, so it's safe to set unconditionally.

## Test plan
- [x] Reproduced by bisecting the crash down to `import cryptography.hazmat.bindings._rust` inside the `api` image, confirmed via `docker compose run --rm -e OPENSSL_armcap=0 ...` that the import succeeds with the flag set.
- [x] `docker compose -f docker-compose.prod.yml up -d` with the fix applied: `api`, `celery`, `postgres`, `redis`, `neo4j`, `app` all reach `healthy`/`Up`.
- [x] `curl http://127.0.0.1:5001/health` returns `{"status":"ok"}`.
- [ ] Not verified on Docker Desktop / native Linux ARM64 / x86_64 (expected no-op there, but untested by me).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3yAhS1TuD13NwPheDuMv6