### PR TITLE
Use timezone-aware Scan start defaults

### DIFF
--- a/flowsint-core/src/flowsint_core/core/models.py
+++ b/flowsint-core/src/flowsint_core/core/models.py
@@ -129,7 +129,7 @@ class Scan(Base):
         nullable=True,
     )
     status = Column(SQLEnum(EventLevel), default=EventLevel.PENDING)
-    started_at = Column(DateTime, default=datetime.utcnow)
+    started_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     completed_at = Column(DateTime, nullable=True)
     error = Column(Text, nullable=True)
     details = Column(JSON, nullable=True)

--- a/flowsint-core/tests/factories.py
+++ b/flowsint-core/tests/factories.py
@@ -127,7 +127,7 @@ class ScanFactory(SQLAlchemyModelFactory):
     sketch = factory.SubFactory(SketchFactory)
     sketch_id = factory.LazyAttribute(lambda o: o.sketch.id)
     status = EventLevel.PENDING
-    started_at = factory.LazyFunction(datetime.utcnow)
+    started_at = factory.LazyFunction(lambda: datetime.now(timezone.utc))
 
 
 class LogFactory(SQLAlchemyModelFactory):


### PR DESCRIPTION
## Summary
- replace the `Scan.started_at` `datetime.utcnow` default with a timezone-aware UTC timestamp
- update the matching factory default so tests/builders create the same style of value

## Problem
`datetime.utcnow()` returns a naive datetime object. The rest of this package already uses `datetime.now(timezone.utc)` in several timestamp paths, so `Scan.started_at` could be inconsistent with timezone-aware values.

## Before / After
Before: newly-created `Scan` rows and `ScanFactory` instances received naive UTC datetimes.

After: both defaults produce timezone-aware UTC datetimes.

## Verification
- `python -m py_compile flowsint-core/src/flowsint_core/core/models.py flowsint-core/tests/factories.py`
- `$env:AUTH_SECRET='test-secret-for-local-pytest'; $env:REDIS_URL='redis://localhost:6379/0'; $env:MASTER_VAULT_KEY_V1='base64:qnHTmwYb+uoygIw9MsRMY22vS5YPchY+QOi/E79GAvM='; $env:NEO4J_URI_BOLT='bolt://127.0.0.1:7687'; $env:NEO4J_USERNAME='neo4j'; $env:NEO4J_PASSWORD='test-password'; uv run --package flowsint-core pytest flowsint-core/tests/services/test_timezone_timestamps.py flowsint-core/tests/repositories/test_scan_repository.py -q`