### PR TITLE
fix(enrichers): dnsx stdin input + configurable Scamalytics API host

### DIFF
--- a/flowsint-enrichers/src/flowsint_enrichers/ip/to_fraudscore.py
+++ b/flowsint-enrichers/src/flowsint_enrichers/ip/to_fraudscore.py
@@ -74,11 +74,16 @@ class IpToFraudScore(Enricher):
         self.ip_risk_mapping = []
 
         api_username = self.get_secret("SCAMLYTICS_USERNAME", os.getenv("SCAMLYTICS_USERNAME")) 
-        api_key = self.get_secret("SCAMLYTICS_API_KEY", os.getenv("SCAMLYTICS_API_KEY")) 
+        api_key = self.get_secret("SCAMLYTICS_API_KEY", os.getenv("SCAMLYTICS_API_KEY"))
+        # Scamalytics assigns each account a numbered API node (api11, api12,
+        # ...); a hardcoded host 404s for every account that is not on it.
+        api_host = self.get_secret(
+            "SCAMLYTICS_API_HOST", os.getenv("SCAMLYTICS_API_HOST", "api12")
+        )
 
         for ip in data:
             try:
-                api_request = requests.get(f'https://api12.scamalytics.com/v3/{api_username}/?key={api_key}&ip={ip.address}', timeout=30)
+                api_request = requests.get(f'https://{api_host}.scamalytics.com/v3/{api_username}/?key={api_key}&ip={ip.address}', timeout=30)
                 
                 if api_request.status_code != 200:
                     Logger.error(

--- a/flowsint-enrichers/src/tools/dockertool.py
+++ b/flowsint-enrichers/src/tools/dockertool.py
@@ -46,7 +46,7 @@ class DockerTool(Tool):
         except ImageNotFound:
             return False
 
-    def launch(self, command: str, volumes: dict = None, timeout: int = 30, environment: dict = None):
+    def launch(self, command, volumes: dict = None, timeout: int = 30, environment: dict = None, entrypoint=None):
         self.install()
         # Merge default environment with custom environment
         env = {"TERM": "dumb"}  # Set terminal type to avoid TTY issues
@@ -54,8 +54,7 @@ class DockerTool(Tool):
             env.update(environment)
 
         try:
-            result = self.client.containers.run(
-                self.image,
+            run_kwargs = dict(
                 command=command,
                 remove=True,
                 stdout=True,
@@ -67,6 +66,11 @@ class DockerTool(Tool):
                 stdin_open=False,  # Ensure stdin is not open
                 environment=env,
             )
+            # Some tools only accept a single target on stdin, which needs a
+            # shell in front of the image's default entrypoint.
+            if entrypoint is not None:
+                run_kwargs["entrypoint"] = entrypoint
+            result = self.client.containers.run(self.image, **run_kwargs)
             return result.decode()
         except ImageNotFound:
             raise RuntimeError(f"Image {self.image} not found. Did you run install()?")

--- a/flowsint-enrichers/src/tools/network/dnsx.py
+++ b/flowsint-enrichers/src/tools/network/dnsx.py
@@ -1,4 +1,5 @@
 import json
+import shlex
 from typing import List
 from ..dockertool import DockerTool
 
@@ -109,14 +110,20 @@ class DnsxTool(DockerTool):
             flags.append("-aaaa")
         flags += ["-json", "-silent"]
 
-        command = f"-d {domain} {' '.join(flags)}"
+        # dnsx >= 1.2 treats `-d` as "bruteforce this domain" and refuses to
+        # run without a `-w` wordlist, so a plain `-d example.com` exits with
+        # "missing wordlist(w) flag required with domain(d) input" and the
+        # enricher silently returns nothing. Feeding the single target on
+        # stdin is the supported invocation.
+        inner = f"dnsx {' '.join(flags)}"
+        command = ["-c", f"echo {shlex.quote(domain)} | {inner}"]
 
         env = {}
         if api_key:
             env["PDCP_API_KEY"] = api_key
 
         try:
-            result = super().launch(command, environment=env)
+            result = super().launch(command, environment=env, entrypoint="sh")
         except Exception as e:
             raise RuntimeError(
                 f"Error running dnsx: {str(e)}. Output: {getattr(e, 'output', 'No output')}"


### PR DESCRIPTION
Two enrichers return an empty result instead of failing loudly, so the task is reported as succeeded and nothing shows up in the graph.

## 1. `domain_to_dns` — dnsx no longer accepts a bare `-d`

`DnsxTool.resolve_domain()` builds:

```
dnsx -d <domain> -a -aaaa -json -silent
```

Since dnsx 1.2, `-d` means *"bruteforce this domain"* and requires a wordlist:

```
$ docker run --rm projectdiscovery/dnsx -d example.com -a -aaaa -json -silent
[FTL] missing wordlist(w) flag required with domain(d) input
$ echo $?
0
```

The exit code is **0**, so nothing raises — the enricher just returns `[]` and Celery logs `succeeded`. From the UI it looks like the domain simply has no DNS records.

**Fix:** feed the single target on stdin, which is the supported single-target invocation:

```
sh -c "echo <domain> | dnsx -a -aaaa -json -silent"
```

`DockerTool.launch()` gains an optional `entrypoint` argument so a shell can be placed in front of the image entrypoint. The domain is passed through `shlex.quote()`.

Verified against `projectdiscovery/dnsx:latest` (v1.2.2):

```
resolve_domain("<a test domain>") -> ['13.227.138.65', '13.227.138.39', '13.227.138.34', '13.227.138.124']
```

## 2. `ip_to_fraudscore` — Scamalytics API host is per-account

The host is hardcoded:

```python
requests.get(f'https://api12.scamalytics.com/v3/{api_username}/?key={api_key}&ip={ip.address}')
```

Scamalytics provisions each account on a numbered API node and hands out the full base URL at signup. An account on a different node gets a plain **404** from `api12`, with the same silent-empty-result outcome. On a live v3 account provisioned on `api11`:

| host | result |
|---|---|
| the account's own node | `200` + full JSON |
| `api12` | `404 Not Found` |

**Fix:** read the host from a `SCAMLYTICS_API_HOST` secret / env var, **defaulting to `api12`** so existing deployments are unchanged.

## Notes

- No behaviour change for anyone already working: the Scamalytics default is preserved, and the dnsx change only alters how the single target is passed.
- Happy to split this into two PRs, add tests, or make the dnsx change use a different mechanism if you prefer — just say the word.
