### PR TITLE
fix(types): handle when self.username is None

### DIFF
--- a/flowsint-types/src/flowsint_types/social_account.py
+++ b/flowsint-types/src/flowsint_types/social_account.py
@@ -92,11 +92,17 @@ class SocialAccount(FlowsintType):
             self.id = f"{self.username.value}@{self.platform}"
         elif self.username:
             self.id = self.username.value
+        else:
+            self.id = self.display_name or "unknown"
         self.nodeLabel = self.id
 
         # Use display name if available, otherwise username
-        if self.display_name:
+        if self.display_name and self.username:
             self.nodeLabel = f"{self.display_name} (@{self.username.value})"
+        elif self.display_name:
+            self.nodeLabel = f"{self.display_name}"
+        elif self.username:
+            self.nodeLabel = f"@{self.username.value}"
         else:
             self.nodeLabel = self.id
         return self

--- a/flowsint-types/src/flowsint_types/social_account.py
+++ b/flowsint-types/src/flowsint_types/social_account.py
@@ -97,12 +97,11 @@ class SocialAccount(FlowsintType):
         self.nodeLabel = self.id
 
         # Use display name if available, otherwise username
-        if self.display_name and self.username:
-            self.nodeLabel = f"{self.display_name} (@{self.username.value})"
-        elif self.display_name:
-            self.nodeLabel = f"{self.display_name}"
-        elif self.username:
-            self.nodeLabel = f"@{self.username.value}"
+        if self.display_name:
+            if self.username:
+                self.nodeLabel = f"{self.display_name} (@{self.username.value})"
+            else:
+                self.nodeLabel = self.display_name
         else:
             self.nodeLabel = self.id
         return self


### PR DESCRIPTION
Fixes an issue where running an enricher (like Maigret) on a Username finds accounts, but `self.username` in `social_account.py` was `None`; adds additional checks for `self.username` and a fallback for `self.id`.

Related traceback: [Hastebin](https://hst.sh/febakivibi.sql)