### PR TITLE
Harden navbar external links

### DIFF
--- a/flowsint-app/src/components/layout/top-navbar.tsx
+++ b/flowsint-app/src/components/layout/top-navbar.tsx
@@ -181,7 +181,12 @@ export function InvestigationMenu({
         </DropdownMenuGroup>
         <DropdownMenuSeparator />
         <DropdownMenuItem>
-          <a className="h-full w-full" target="_blank" href="https://github.com/reconurge/flowsint">
+          <a
+            className="h-full w-full"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://github.com/reconurge/flowsint"
+          >
             GitHub
           </a>
         </DropdownMenuItem>
@@ -189,6 +194,7 @@ export function InvestigationMenu({
           <a
             className="h-full w-full"
             target="_blank"
+            rel="noopener noreferrer"
             href="https://github.com/reconurge/flowsint/issues"
           >
             Support


### PR DESCRIPTION
## Problem

Two external links in the dashboard navbar open with `target="_blank"` but do not set a `rel` attribute. Other external links in the app already use `rel="noopener noreferrer"`, so these two were inconsistent with the safer pattern.

## Before / after

Before, the GitHub and Support dropdown links opened a new tab without explicitly isolating the opener context.

After, both links include `rel="noopener noreferrer"`, matching the rest of the app's external-link handling.

## Verification

- `../node_modules/.bin/prettier.cmd --check src/components/layout/top-navbar.tsx`
- `git diff --check`

I also tried `npm run typecheck`, but it currently fails on unrelated existing TypeScript errors across the app, including missing `@tiptap/react/menus`, missing `@tiptap/markdown`, and several pre-existing implicit-any/unused import errors outside this navbar file.