### PR TITLE
fix(enrichers): fix missing display_name, bio, location, and created_at from username_to_socials_maigret

### DIFF
--- a/flowsint-enrichers/src/flowsint_enrichers/social/to_maigret.py
+++ b/flowsint-enrichers/src/flowsint_enrichers/social/to_maigret.py
@@ -95,14 +95,24 @@ class MaigretEnricher(Enricher):
             except ValueError:
                 followers = following = posts = None
 
+            display_name = ids.get("fullname") or ids.get("nickname")
+            if display_name:
+                nodeLabel = f"{display_name} ({platform})"
+            else:
+                nodeLabel = None
+
             try:
                 results.append(
                     SocialAccount(
+                        nodeLabel=nodeLabel,
                         username=username_obj,
+                        display_name=display_name,
                         profile_url=profile_url,
-                        platform=platform,
                         profile_picture_url=ids.get("image"),
-                        bio=None,
+                        bio=ids.get("bio"),
+                        location=ids.get("location"),
+                        platform=platform,
+                        created_at=ids.get("created_at"),
                         followers_count=followers,
                         following_count=following,
                         posts_count=posts,

--- a/flowsint-types/src/flowsint_types/social_account.py
+++ b/flowsint-types/src/flowsint_types/social_account.py
@@ -92,13 +92,20 @@ class SocialAccount(FlowsintType):
             self.id = f"{self.username.value}@{self.platform}"
         elif self.username:
             self.id = self.username.value
-        self.nodeLabel = self.id
-
-        # Use display name if available, otherwise username
-        if self.display_name:
-            self.nodeLabel = f"{self.display_name} (@{self.username.value})"
         else:
+            self.id = self.display_name or "unknown"
+        
+        # Only modify nodeLabel if it isn't set
+        if not self.nodeLabel:
             self.nodeLabel = self.id
+
+            # Use display name if available, otherwise username
+            if self.display_name:
+                if self.username:
+                    self.nodeLabel = f"{self.display_name} (@{self.username.value})"
+                else:
+                    self.nodeLabel = self.display_name
+
         return self
 
     @classmethod


### PR DESCRIPTION
Adds the values `display_name`, `bio`, `location`, and `created_at` to nodes created by the Maigret enricher since it was previously only adding `username`, `profile_url`, `profile_picture_url`, `platform`, `followers_count`, `following_count`, and `posts_count`.

This also manually sets `nodeLabel` if any sort of display name exists to "display_name (platform)" since the enricher already creates relationships with the Username node.

Also includes the fix from https://github.com/reconurge/flowsint/pull/201.