### PR TITLE
fix: increase Neo4j healthcheck timeout

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -57,10 +57,11 @@ services:
     networks:
       - flowsint_network
     healthcheck:
-      test: cypher-shell -u ${NEO4J_USERNAME} -p ${NEO4J_PASSWORD} "RETURN 1"
-      interval: 5s
-      timeout: 5s
+      test: ["CMD-SHELL", "cypher-shell -u ${NEO4J_USERNAME} -p ${NEO4J_PASSWORD} \"RETURN 1\""]
+      interval: 10s
+      timeout: 20s
       retries: 10
+      start_period: 30s
 
   api:
     image: ghcr.io/reconurge/flowsint-api:${FLOWSINT_VERSION:-latest}


### PR DESCRIPTION
## Description

The Neo4j container can be incorrectly marked as unhealthy during startup because the current healthcheck has a 5-second timeout.

On my system, Neo4j successfully starts, but:

`cypher-shell -u neo4j -p password "RETURN 1"`

takes around 12.5 seconds to complete.

This causes the healthcheck to time out even though Neo4j is actually running correctly, which prevents dependent services from starting with `make prod`.

## Changes

- Increased the healthcheck interval from 5s to 10s
- Increased the timeout from 5s to 20s
- Added a 30s start period
- Kept 10 retries
- Explicitly defined the healthcheck as `CMD-SHELL`

## Testing

Tested locally with Docker Compose:

- `docker compose -f docker-compose.prod.yml config` → YAML OK
- Neo4j container → healthy
- PostgreSQL → healthy
- Redis → healthy
- API → healthy
- App → healthy

The Neo4j healthcheck now succeeds on the affected system.