### PR TITLE
fix: increase Celery healthcheck timeout

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -126,7 +126,7 @@ services:
       # Use celery's own ping primitive instead.
       test: ["CMD-SHELL", "celery -A flowsint_core.core.celery inspect ping -d celery@$$HOSTNAME || exit 1"]
       interval: 30s
-      timeout: 10s
+      timeout: 20s
       retries: 3
       start_period: 30s
     depends_on:


### PR DESCRIPTION
## Summary
- Increase the Celery healthcheck timeout from 10s to 20s.
- Prevent false unhealthy status when the Celery ping takes longer than 10 seconds.

## Validation
- Celery container reports `healthy`.
- `celery inspect ping` returns `pong`.