### PR TITLE
Add stdio MCP wrapper with declarative YAML allowlist governance

### DIFF
--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -1,0 +1,4 @@
+.env
+allowlist.yaml
+__pycache__/
+CONOUT$

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,96 @@
+# flowsint MCP wrapper
+
+Small stdio JSON-RPC wrapper that exposes a governed subset of the flowsint
+FastAPI as [Model Context Protocol](https://modelcontextprotocol.io) tools,
+so an LLM assistant can drive company-infrastructure recon safely.
+
+**Governance is data, not code.** A YAML allowlist (`allowlist.yaml`) is the
+single source of truth for what enrichers may run. Default-deny is structural:
+anything not declared is rejected. Edit the YAML, wait <= 60 s, no restart.
+
+## What ships in `mcp/`
+
+| File | Purpose |
+|---|---|
+| `flowsint_mcp.py`     | JSON-RPC stdio loop; registers 7 tools. |
+| `flowsint_client.py`  | Stdlib HTTP client, auth, graph/health helpers. |
+| `allowlist_loader.py` | YAML classifier with 60 s mtime TTL. Fail-closed. |
+| `allowlist.example.yaml` | Bundled sample - 26 upstream enrichers + denylist. Used as fallback when `allowlist.yaml` is absent, so a fresh clone still boots deny-by-defaults. |
+| `otel_bootstrap.py`   | OTLP HTTP spans; graceful-degrade if OTel SDK is missing. |
+| `metrics.py`          | `mcp_tool_calls_total{tool,result}` counter via OTLP + optional Pushgateway. |
+| `env.example`         | Config template. Copy to `.env` and fill. |
+
+## Tools exposed
+
+| Name | Description |
+|---|---|
+| `flowsint_list_enrichers` | Live enrichers filtered by the allowlist. |
+| `flowsint_recon_company`  | Seeds a Domain / Organization sketch and launches the safe infra enrichers. |
+| `flowsint_launch_enricher`| Single-enricher pivot on an existing node. |
+| `flowsint_get_graph`      | Nodes + relationships for a sketch (truncated at 200). |
+| `flowsint_status`         | Recent run logs for a sketch. |
+| `flowsint_load_custom_templates_from_disk` | Upserts YAML templates from `FLOWSINT_TEMPLATES_DIR`. Governed by the allowlist. |
+| `flowsint_health`         | api / celery / redis / neo4j / allowlist / OTel status. |
+
+## Quick start
+
+1. `cp env.example .env` and fill `FLOWSINT_USER` / `FLOWSINT_PASS`.
+2. `cp allowlist.example.yaml allowlist.yaml` and adjust to your policy.
+3. Wire the wrapper into your MCP host (Claude Desktop, VS Code, ...):
+
+```json
+{
+  "mcpServers": {
+    "flowsint": {
+      "command": "python",
+      "args": ["/path/to/flowsint/mcp/flowsint_mcp.py"]
+    }
+  }
+}
+```
+
+4. Optional: install OTel deps for tracing/metrics.
+
+```
+pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
+```
+
+## Governance model
+
+`classify_enricher(name)` runs on every call:
+
+1. Name not declared in `allowlist` -> **DENY** (default-deny).
+2. Name declared in `forbidden` -> **DENY** with the given reason.
+3. Entry with `pii_touched: true` -> **DENY**; requires explicit re-authorization.
+4. `input_type` not in `allowed_infra_types` -> **DENY**.
+5. Otherwise -> **ALLOW**.
+
+`allowlist.yaml` is your compliance trail. Every entry records
+`authorized_by` / `authorized_date` / `reviewed_by` so the audit story
+is diff-able in git rather than buried in a Python set.
+
+Adding a template:
+
+1. Write the YAML file (see `../templates/` in your fork).
+2. Add its entry to `allowlist.yaml` under `allowlist:` with
+   `source: template` and `template_path: ...`.
+3. Call `flowsint_load_custom_templates_from_disk()` from the MCP host.
+   The tool cross-checks against `allowlist.yaml` and upserts via
+   `POST /api/enrichers/templates` (create) or
+   `PUT /api/enrichers/templates/<id>` (update).
+
+## Observability
+
+- Every tool call emits an OTel span `flowsint.tools.<tool_name>` with
+  attributes `{tool_name, result}` where `result in {ok, deny, error}`.
+- A counter `mcp_tool_calls_total{tool, result}` is exported via OTLP;
+  a Prometheus Pushgateway fallback is available if `PUSHGATEWAY_URL` is set.
+- Both channels degrade to no-op if the OTel SDK is not installed or if
+  `OTEL_EXPORTER_OTLP_ENDPOINT` is empty - the MCP still works.
+
+## Notes
+
+- `flowsint_health` reports Celery as `unknown` when the API does not
+  expose `/api/workers`. A follow-up upstream contribution can wire
+  a real worker liveness endpoint.
+- The wrapper uses stdlib + PyYAML only. OTel deps are optional.

--- a/mcp/allowlist.example.yaml
+++ b/mcp/allowlist.example.yaml
@@ -1,0 +1,105 @@
+# flowsint MCP wrapper -- allowlist.yaml sample
+#
+# Governance is DATA, not code. Copy this file to `allowlist.yaml` in the
+# SAME folder and edit the entries to match your deployment's ethics /
+# legal posture (LFPDPPP, GDPR, in-house policy, ...). Any enricher name
+# not declared below is rejected structurally (default-deny). Auto-reload
+# picks up edits within ~60 s (mtime-stat TTL).
+#
+# Each `allowlist` entry supports:
+#   name              (required) enricher name registered in flowsint
+#   source            "upstream" | "template" | "custom"
+#   input_type        (required) must appear in `allowed_infra_types`
+#   output_type       label for humans (not enforced by the classifier)
+#   external_api      "none" or the third-party service name
+#   pii_touched       true forces DENY (requires explicit re-authorization)
+#   authorized_by     free text (compliance trail)
+#   authorized_date   ISO date (compliance trail)
+#   reviewed_by       free text (governance trail)
+#   ttl_seconds       optional hint for callers that cache by seed
+#   notes             optional free text
+#
+# `forbidden` is decorative -- default-deny already rejects any name not
+# in `allowlist`. It exists only to produce clearer error messages when a
+# known-bad enricher is called.
+---
+version: 1
+schema_notes:
+  ttl_seconds_default: 300
+  ttl_seconds_dns: 86400        # DNS/WHOIS are deterministic ~24 h
+  reviewed_at: "2026-08-20"
+
+allowlist:
+  # -------- upstream reconurge/flowsint enrichers (safe infra-only set) --------
+  - {name: domain_to_asn,            source: upstream, input_type: Domain,       output_type: Asn,          external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 86400}
+  - {name: domain_to_dns,            source: upstream, input_type: Domain,       output_type: DomainRecord, external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 86400}
+  - {name: domain_to_history,        source: upstream, input_type: Domain,       output_type: History,      external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 300}
+  - {name: domain_to_ip,             source: upstream, input_type: Domain,       output_type: Ip,           external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 86400}
+  - {name: domain_to_root_domain,    source: upstream, input_type: Domain,       output_type: Domain,       external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 86400}
+  - {name: domain_to_subdomains,     source: upstream, input_type: Domain,       output_type: Domain,       external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 86400}
+  - {name: domain_to_tls,            source: upstream, input_type: Domain,       output_type: Tls,          external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 86400}
+  - {name: domain_to_website,        source: upstream, input_type: Domain,       output_type: Website,      external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 86400}
+  - {name: domain_to_whois,          source: upstream, input_type: Domain,       output_type: Whois,        external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 86400}
+  - {name: domain_to_whois_history,  source: upstream, input_type: Domain,       output_type: Whois,        external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 86400}
+  - {name: asn_to_cidrs,             source: upstream, input_type: Asn,          output_type: Cidr,         external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 86400}
+  - {name: cidr_to_ips,              source: upstream, input_type: Cidr,         output_type: Ip,           external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 86400}
+  - {name: ip_to_asn,                source: upstream, input_type: Ip,           output_type: Asn,          external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 86400}
+  - {name: ip_to_domain,             source: upstream, input_type: Ip,           output_type: Domain,       external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 86400}
+  - {name: ip_to_infos,              source: upstream, input_type: Ip,           output_type: Info,         external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 86400}
+  - {name: ip_to_ports,              source: upstream, input_type: Ip,           output_type: Port,         external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 300}
+  - {name: org_to_asn,               source: upstream, input_type: Organization, output_type: Asn,          external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 86400}
+  - {name: org_to_domains,           source: upstream, input_type: Organization, output_type: Domain,       external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 86400}
+  - {name: org_to_infos,             source: upstream, input_type: Organization, output_type: Info,         external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 86400}
+  - {name: website_to_crawler,       source: upstream, input_type: Website,      output_type: CrawlResult,  external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 3600}
+  - {name: website_to_domain,        source: upstream, input_type: Website,      output_type: Domain,       external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 3600}
+  - {name: website_to_links,         source: upstream, input_type: Website,      output_type: Link,         external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 3600}
+  - {name: website_to_subdomains,    source: upstream, input_type: Website,      output_type: Domain,       external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 86400}
+  - {name: website_to_text,          source: upstream, input_type: Website,      output_type: Text,         external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 3600}
+  - {name: website_to_webtrackers,   source: upstream, input_type: Website,      output_type: Tracker,      external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 3600}
+  - {name: tech_detect,              source: upstream, input_type: Website,      output_type: Technology,   external_api: none, pii_touched: false, authorized_by: reviewer, authorized_date: "2026-08-20", reviewed_by: reviewer, ttl_seconds: 3600}
+  # -------- your local YAML templates go here --------
+  # - name: my-custom-enricher
+  #   source: template
+  #   template_path: ./templates/my-custom-enricher.yaml
+  #   input_type: Domain
+  #   output_type: Phrase
+  #   external_api: some-public-service
+  #   pii_touched: false
+  #   authorized_by: your-name
+  #   authorized_date: "2026-08-20"
+  #   reviewed_by: your-reviewer
+  #   ttl_seconds: 86400
+
+# Denylist for clearer error messages. The default-deny above is the real gate.
+forbidden:
+  - {name: individual_to_domains,          reason: "person recon is out of scope for this deployment"}
+  - {name: individual_to_organization,     reason: "person recon is out of scope for this deployment"}
+  - {name: email_to_breaches,              reason: "breach data is out of scope"}
+  - {name: email_to_device_hudsonrock,     reason: "infostealer data is out of scope"}
+  - {name: email_to_domain,                reason: "email as seed is out of scope"}
+  - {name: email_to_domains,               reason: "email as seed is out of scope"}
+  - {name: email_to_gravatar,              reason: "gravatar PII is out of scope"}
+  - {name: email_to_intelligence,          reason: "third-party email intelligence is out of scope"}
+  - {name: email_to_username,              reason: "email->username pivot is out of scope"}
+  - {name: phone_to_carrier,               reason: "phone as seed is out of scope"}
+  - {name: phone_to_device_hudsonrock,     reason: "infostealer data is out of scope"}
+  - {name: phone_to_infos,                 reason: "phone as seed is out of scope"}
+  - {name: username_to_dehashed,           reason: "dehashed is out of scope"}
+  - {name: username_to_device_hudsonrock,  reason: "infostealer data is out of scope"}
+  - {name: username_to_socials_maigret,    reason: "username social recon is out of scope"}
+  - {name: username_to_socials_sherlock,   reason: "username social recon is out of scope"}
+  - {name: domain_to_dehashed,             reason: "dehashed is out of scope"}
+  - {name: domain_to_dummy,                reason: "test enricher; not useful in production"}
+  - {name: ip_to_dummy_domains,            reason: "test enricher; not useful in production"}
+  - {name: ip_to_fraudscore,               reason: "third-party fraudscore is out of scope"}
+  - {name: ip_to_intelligence,             reason: "third-party ip intelligence is out of scope"}
+  - {name: cryptowallet_to_nfts,           reason: "crypto tracing is out of scope"}
+  - {name: cryptowallet_to_transactions,   reason: "crypto tracing is out of scope"}
+
+allowed_infra_types:
+  - Domain
+  - Ip
+  - Asn
+  - Cidr
+  - Organization
+  - Website

--- a/mcp/allowlist_loader.py
+++ b/mcp/allowlist_loader.py
@@ -1,0 +1,160 @@
+"""Declarative allowlist loader for the flowsint MCP wrapper.
+
+Reads `allowlist.yaml` (same folder) with a 60 s mtime-stat TTL — edits are
+picked up without restart. Default-deny is structural: any enricher not
+declared is rejected. See allowlist.yaml header for the full rule set.
+"""
+from __future__ import annotations
+
+import os
+import time
+import threading
+from typing import Any
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_YAML_PATH = os.environ.get("FLOWSINT_ALLOWLIST_PATH") or os.path.join(_HERE, "allowlist.yaml")
+_YAML_FALLBACK = os.path.join(_HERE, "allowlist.example.yaml")
+_TTL_SECONDS = 60
+
+_LOCK = threading.Lock()
+_CACHE: dict[str, Any] = {
+    "loaded_at": 0.0,
+    "mtime": 0.0,
+    "allowlist_by_name": {},
+    "forbidden_by_name": {},
+    "allowed_infra_types": set(),
+    "raw": None,
+    "error": None,
+}
+
+
+class AllowlistError(Exception):
+    pass
+
+
+def _reload_if_stale() -> None:
+    now = time.time()
+    if _CACHE["loaded_at"] and (now - _CACHE["loaded_at"]) < _TTL_SECONDS:
+        return
+    with _LOCK:
+        if _CACHE["loaded_at"] and (now - _CACHE["loaded_at"]) < _TTL_SECONDS:
+            return
+        # Prefer the operator-supplied allowlist.yaml; fall back to the
+        # bundled example so a fresh clone still deny-by-defaults instead of
+        # failing hard. Operators who want to force explicit configuration
+        # can set FLOWSINT_ALLOWLIST_PATH to a non-existent path and this
+        # will surface as `state().error`.
+        active_path = _YAML_PATH if os.path.exists(_YAML_PATH) else _YAML_FALLBACK
+        try:
+            mtime = os.path.getmtime(active_path)
+        except OSError as exc:
+            _CACHE["error"] = "allowlist unavailable: %s" % exc
+            _CACHE["loaded_at"] = now
+            return
+        if _CACHE["mtime"] == mtime and _CACHE["allowlist_by_name"]:
+            _CACHE["loaded_at"] = now
+            return
+        if yaml is None:
+            _CACHE["error"] = "PyYAML not installed; allowlist cannot be parsed"
+            _CACHE["loaded_at"] = now
+            return
+        try:
+            with open(active_path, encoding="utf-8") as fh:
+                data = yaml.safe_load(fh)
+        except Exception as exc:
+            _CACHE["error"] = "allowlist parse failed: %s" % exc
+            _CACHE["loaded_at"] = now
+            return
+        if not isinstance(data, dict):
+            _CACHE["error"] = "allowlist.yaml root must be a mapping"
+            _CACHE["loaded_at"] = now
+            return
+        allowlist_by_name: dict[str, dict] = {}
+        for entry in data.get("allowlist") or []:
+            if isinstance(entry, dict) and entry.get("name"):
+                allowlist_by_name[str(entry["name"]).strip()] = entry
+        forbidden_by_name: dict[str, dict] = {}
+        for entry in data.get("forbidden") or []:
+            if isinstance(entry, dict) and entry.get("name"):
+                forbidden_by_name[str(entry["name"]).strip()] = entry
+        allowed_infra_types = {str(t).strip() for t in (data.get("allowed_infra_types") or [])}
+        if not allowed_infra_types:
+            allowed_infra_types = {"Domain", "Ip", "Asn", "Cidr", "Organization", "Website"}
+        _CACHE.update({
+            "loaded_at": now,
+            "mtime": mtime,
+            "allowlist_by_name": allowlist_by_name,
+            "forbidden_by_name": forbidden_by_name,
+            "allowed_infra_types": allowed_infra_types,
+            "raw": data,
+            "error": None,
+        })
+
+
+def state() -> dict:
+    _reload_if_stale()
+    active_path = _YAML_PATH if os.path.exists(_YAML_PATH) else _YAML_FALLBACK
+    return {
+        "path": active_path,
+        "using_fallback_example": not os.path.exists(_YAML_PATH),
+        "mtime": _CACHE["mtime"],
+        "loaded_at": _CACHE["loaded_at"],
+        "allowlist_count": len(_CACHE["allowlist_by_name"]),
+        "forbidden_count": len(_CACHE["forbidden_by_name"]),
+        "allowed_infra_types": sorted(_CACHE["allowed_infra_types"]),
+        "error": _CACHE["error"],
+    }
+
+
+def get_entry(name: str) -> dict | None:
+    _reload_if_stale()
+    return _CACHE["allowlist_by_name"].get((name or "").strip())
+
+
+def all_entries() -> list[dict]:
+    _reload_if_stale()
+    return list(_CACHE["allowlist_by_name"].values())
+
+
+def classify_enricher(name: str) -> tuple[bool, str, dict | None]:
+    """Return (allowed, reason, entry_or_None). Default-deny.
+
+    reason is the enricher name if allowed (mirrors the previous wrapper's
+    contract), or an explicit denial string otherwise.
+    """
+    _reload_if_stale()
+    err = _CACHE["error"]
+    if err:
+        return (False, "allowlist unavailable: %s" % err, None)
+    key = (name or "").strip()
+    if not key:
+        return (False, "empty enricher name", None)
+    forbidden = _CACHE["forbidden_by_name"].get(key)
+    if forbidden:
+        return (False, "forbidden by governance (LFPDPPP): %s" % forbidden.get("reason", "denied"), None)
+    entry = _CACHE["allowlist_by_name"].get(key)
+    if entry is None:
+        return (False, "not in infrastructure allowlist (default-deny)", None)
+    if entry.get("pii_touched"):
+        return (False, "declared pii_touched=true in allowlist.yaml — requires Saurat re-authorization", entry)
+    input_type = str(entry.get("input_type") or "").strip()
+    if input_type not in _CACHE["allowed_infra_types"]:
+        return (False, "input_type=%s not in allowed_infra_types" % input_type, entry)
+    return (True, key, entry)
+
+
+def enricher_input_type(name: str) -> str | None:
+    entry = get_entry(name)
+    if entry:
+        return str(entry.get("input_type") or "").strip() or None
+    return None
+
+
+def templates() -> list[dict]:
+    """Only the entries declared as source: template."""
+    return [e for e in all_entries() if str(e.get("source") or "").strip() == "template"]

--- a/mcp/env.example
+++ b/mcp/env.example
@@ -1,0 +1,39 @@
+# flowsint MCP wrapper config.
+# Copy this file to ".env" in the SAME folder (mcp/.env) and fill in the values.
+#   cp env.example .env     # then edit .env
+# The .env file is gitignored; never commit real credentials.
+
+# flowsint FastAPI base (no trailing slash)
+FLOWSINT_API=http://127.0.0.1:5001
+
+# flowsint web UI base (used to build web_url links)
+FLOWSINT_WEB=http://localhost:5173
+
+# flowsint account (register once at http://localhost:5173/register).
+# Use a dedicated service account, NOT a personal login.
+FLOWSINT_USER=
+FLOWSINT_PASS=
+
+# Optional: HTTP timeout in seconds (default 30)
+FLOWSINT_TIMEOUT=30
+
+# Custom YAML templates dir for flowsint_load_custom_templates_from_disk.
+# Defaults to ./templates next to this file.
+FLOWSINT_TEMPLATES_DIR=
+
+# Health check overrides (default 127.0.0.1 / standard ports)
+REDIS_HOST=127.0.0.1
+REDIS_PORT=6379
+NEO4J_HOST=127.0.0.1
+NEO4J_BOLT_PORT=7687
+
+# OpenTelemetry. Empty endpoint = tracing/metrics off (graceful degrade).
+OTEL_ENABLED=1
+OTEL_SERVICE_NAME=mcp-flowsint
+OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318
+OTEL_EXPORTER_OTLP_HEADERS=
+OTEL_TRACES_SAMPLER_ARG=1.0
+
+# Optional Prometheus Pushgateway. If set, wrapper POSTs mcp_tool_calls_total
+# to /metrics/job/<OTEL_SERVICE_NAME>. Leave empty for OTLP-only.
+PUSHGATEWAY_URL=

--- a/mcp/flowsint_client.py
+++ b/mcp/flowsint_client.py
@@ -1,0 +1,166 @@
+"""Thin HTTP client + helpers for the flowsint FastAPI. Stdlib only.
+
+Kept separate from flowsint_mcp.py so the wrapper stays close to the JSON-RPC
+loop / tool orchestration. All governance decisions live in allowlist_loader.
+"""
+from __future__ import annotations
+
+import json
+import re
+import socket
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+class ApiError(Exception):
+    pass
+
+
+class FlowsintClient:
+    def __init__(self, api_url: str, user: str, password: str, timeout: int = 30):
+        self.api = api_url.rstrip("/")
+        self.user = user
+        self.password = password
+        self.timeout = timeout
+        self._token: str | None = None
+
+    def _request(self, method, path, token=None, json_body=None, form_body=None,
+                 query=None, timeout=None):
+        url = self.api + path
+        if query:
+            url += "?" + urllib.parse.urlencode({k: v for k, v in query.items() if v is not None})
+        data, headers = None, {"Accept": "application/json"}
+        if json_body is not None:
+            data = json.dumps(json_body).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        elif form_body is not None:
+            data = urllib.parse.urlencode(form_body).encode("utf-8")
+            headers["Content-Type"] = "application/x-www-form-urlencoded"
+        if token:
+            headers["Authorization"] = "Bearer " + token
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(req, timeout=timeout or self.timeout) as resp:
+                raw = resp.read().decode("utf-8", "replace")
+                return resp.status, (json.loads(raw) if raw.strip() else None)
+        except urllib.error.HTTPError as e:
+            raw = e.read().decode("utf-8", "replace")
+            try:
+                body = json.loads(raw)
+            except Exception:
+                body = raw
+            return e.code, body
+        except urllib.error.URLError as e:
+            raise ApiError("flowsint API unreachable at %s (%s)" % (self.api, e.reason))
+
+    def _auth(self):
+        if not self.user or not self.password:
+            raise ApiError("account pending: FLOWSINT_USER/FLOWSINT_PASS not set in mcp/.env")
+        status, body = self._request(
+            "POST", "/api/auth/token",
+            form_body={"username": self.user, "password": self.password, "grant_type": "password"},
+        )
+        if status == 401:
+            raise ApiError("login 401: flowsint account pending or bad credentials")
+        if status >= 400 or not isinstance(body, dict) or "access_token" not in body:
+            raise ApiError("auth failed (HTTP %s): %s" % (status, str(body)[:200]))
+        self._token = body["access_token"]
+        return self._token
+
+    def call(self, method, path, json_body=None, query=None, timeout=None):
+        token = self._token or self._auth()
+        status, body = self._request(method, path, token=token, json_body=json_body,
+                                     query=query, timeout=timeout)
+        if status == 401:
+            token = self._auth()
+            status, body = self._request(method, path, token=token, json_body=json_body,
+                                         query=query, timeout=timeout)
+        if status >= 400:
+            raise ApiError("HTTP %s on %s: %s" % (status, path, str(body)[:300]))
+        return body
+
+    def owner_id(self):
+        try:
+            me = self.call("GET", "/api/auth/me")
+            if isinstance(me, dict):
+                return me.get("id")
+        except ApiError:
+            return None
+        return None
+
+    def enrichers(self):
+        body = self.call("GET", "/api/enrichers")
+        items = body if isinstance(body, list) else (body.get("enrichers") or body.get("data") or [])
+        return [{"raw": it, "name": _enricher_name(it)} for it in items]
+
+
+def _enricher_name(item):
+    if isinstance(item, str):
+        return item
+    if isinstance(item, dict):
+        for k in ("name", "id", "slug", "title", "key"):
+            if item.get(k):
+                return str(item[k])
+    return str(item)
+
+
+def detect_seed_type(seed):
+    """Return the CAPITALIZED flowsint node type or raise on forbidden seed."""
+    s = (seed or "").strip()
+    if not s:
+        raise ApiError("empty seed")
+    if "@" in s:
+        raise ApiError("forbidden by governance (LFPDPPP): infrastructure recon only (email seed rejected)")
+    digits = re.sub(r"\D", "", s)
+    if digits and len(digits) >= 7 and re.fullmatch(r"[\d\s+().-]+", s):
+        raise ApiError("forbidden by governance (LFPDPPP): infrastructure recon only (phone seed rejected)")
+    if " " not in s and re.fullmatch(r"[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}", s):
+        return "Domain"
+    return "Organization"
+
+
+def summarize_graph(g):
+    nodes = (g.get("nds") or g.get("nodes")) if isinstance(g, dict) else None
+    rels = (g.get("rls") or g.get("relationships") or g.get("edges") or g.get("relations")) if isinstance(g, dict) else None
+    nodes = nodes or []
+    rels = rels or []
+    n_sum = []
+    for n in nodes[:200]:
+        if isinstance(n, dict):
+            n_sum.append({"id": n.get("id"),
+                          "label": n.get("nodeLabel") or n.get("label"),
+                          "type": n.get("nodeType") or n.get("type")})
+    r_sum = []
+    for r in rels[:200]:
+        if isinstance(r, dict):
+            r_sum.append({"source": r.get("source"), "target": r.get("target"),
+                          "label": r.get("label")})
+    return {"node_count": len(nodes), "relationship_count": len(rels),
+            "nodes": n_sum, "relationships": r_sum,
+            "truncated": len(nodes) > 200 or len(rels) > 200}
+
+
+def check_tcp(host, port, timeout=1.5):
+    t0 = time.time()
+    try:
+        with socket.create_connection((host, int(port)), timeout=timeout):
+            return {"status": "up", "latency_ms": round((time.time() - t0) * 1000, 1)}
+    except Exception as exc:
+        return {"status": "down", "latency_ms": None, "error": str(exc)[:120]}
+
+
+def check_http(url, timeout=2.0):
+    t0 = time.time()
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            resp.read(1)
+            return {"status": "up" if resp.status < 500 else "degraded",
+                    "http_code": resp.status,
+                    "latency_ms": round((time.time() - t0) * 1000, 1)}
+    except urllib.error.HTTPError as e:
+        return {"status": "degraded", "http_code": e.code,
+                "latency_ms": round((time.time() - t0) * 1000, 1)}
+    except Exception as exc:
+        return {"status": "down", "http_code": None, "error": str(exc)[:120]}

--- a/mcp/flowsint_mcp.py
+++ b/mcp/flowsint_mcp.py
@@ -1,0 +1,395 @@
+"""flowsint MCP wrapper — stdio JSON-RPC over the flowsint FastAPI.
+
+Governance is DATA, not code: `allowlist.yaml` next to this file is the single
+source of truth for what enrichers may be launched. Default-deny is structural
+— any name not declared is rejected. Copy `allowlist.example.yaml` to
+`allowlist.yaml` and edit for your deployment.
+
+Modules:
+    allowlist_loader   YAML classifier with 60 s mtime TTL
+    flowsint_client    HTTP + auth + graph/health helpers (stdlib)
+    otel_bootstrap     spans -> OTLP HTTP
+    metrics            counter -> OTLP + optional Pushgateway
+
+Config (.env; see env.example):
+    FLOWSINT_API              default http://127.0.0.1:5001
+    FLOWSINT_WEB              default http://localhost:5173
+    FLOWSINT_USER / _PASS     required
+    FLOWSINT_TIMEOUT          default 30
+    FLOWSINT_TEMPLATES_DIR    default ./templates
+    OTEL_EXPORTER_OTLP_ENDPOINT   e.g. http://127.0.0.1:4318
+    OTEL_SERVICE_NAME             default mcp-flowsint
+    PUSHGATEWAY_URL           optional fallback
+"""
+import glob
+import json
+import os
+import sys
+import urllib.parse
+import uuid
+
+from allowlist_loader import (
+    all_entries, classify_enricher,
+    state as allowlist_state, templates as allowlist_templates,
+)
+from flowsint_client import (
+    ApiError, FlowsintClient, check_http, check_tcp,
+    detect_seed_type, summarize_graph,
+)
+import metrics
+import otel_bootstrap
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ENV = {}
+_env_path = os.path.join(HERE, ".env")
+if os.path.exists(_env_path):
+    with open(_env_path, encoding="utf-8") as f:
+        for ln in f:
+            ln = ln.strip()
+            if ln and not ln.startswith("#") and "=" in ln:
+                k, v = ln.split("=", 1)
+                ENV[k.strip()] = v.strip()
+                os.environ.setdefault(k.strip(), v.strip())
+
+API = (ENV.get("FLOWSINT_API") or "http://127.0.0.1:5001").rstrip("/")
+WEB = (ENV.get("FLOWSINT_WEB") or "http://localhost:5173").rstrip("/")
+TEMPLATES_DIR = ENV.get("FLOWSINT_TEMPLATES_DIR") or os.path.join(HERE, "templates")
+
+CLIENT = FlowsintClient(API, ENV.get("FLOWSINT_USER", ""), ENV.get("FLOWSINT_PASS", ""),
+                        timeout=int(ENV.get("FLOWSINT_TIMEOUT", "30")))
+
+otel_bootstrap.init()
+metrics.init()
+
+
+def tool_list_enrichers(_p):
+    live = CLIENT.enrichers()
+    declared = {e["name"]: e for e in all_entries()}
+    allowed, excluded = [], []
+    live_names = set()
+    for e in live:
+        live_names.add(e["name"])
+        ok, reason, entry = classify_enricher(e["name"])
+        if ok and entry:
+            allowed.append({
+                "api_name": e["name"],
+                "input_type": entry.get("input_type"),
+                "output_type": entry.get("output_type"),
+                "source": entry.get("source"),
+                "external_api": entry.get("external_api"),
+                "reviewed_by": entry.get("reviewed_by"),
+            })
+        else:
+            excluded.append({"api_name": e["name"], "reason": reason})
+    declared_not_live = [
+        {"name": n, "source": declared[n].get("source"),
+         "notes": "declared in allowlist.yaml but not registered in flowsint API"}
+        for n in sorted(set(declared) - live_names)
+    ]
+    st = allowlist_state()
+    return {
+        "api": API,
+        "allowlist_source": st["path"],
+        "allowlist_entries": st["allowlist_count"],
+        "allowlisted": allowed,
+        "allowlisted_count": len(allowed),
+        "excluded_count": len(excluded),
+        "excluded_sample": excluded[:10],
+        "declared_not_live": declared_not_live,
+        "note": "Data-driven allowlist (allowlist.yaml). Default-deny; edits picked up via 60 s mtime TTL.",
+    }
+
+
+def tool_recon_company(p):
+    seed = (p.get("seed_domain") or p.get("org_name") or p.get("seed") or "").strip()
+    node_type = detect_seed_type(seed)
+    name = p.get("name") or ("Infra recon: %s" % seed)
+    only = p.get("only") or []
+    only_set = set(only) if isinstance(only, list) else set()
+
+    enrichers = CLIENT.enrichers()
+    live_names = {e["name"] for e in enrichers}
+    selected, skipped = [], []
+    for e in enrichers:
+        ok, _reason, entry = classify_enricher(e["name"])
+        if ok and (entry or {}).get("input_type") == node_type:
+            if only_set and e["name"] not in only_set:
+                continue
+            selected.append(e["name"])
+        elif not ok:
+            skipped.append(e["name"])
+    unknown_only = sorted(only_set - live_names)
+    non_allowlisted_only = sorted(
+        n for n in (only_set - set(selected))
+        if n in live_names and not classify_enricher(n)[0]
+    )
+
+    owner_id = CLIENT.owner_id()
+    inv_body = {"name": name, "description": "Company infrastructure recon (governed; infra-only)."}
+    sk_body = {"title": name, "description": "Infra recon sketch (governed)."}
+    if owner_id:
+        inv_body["owner_id"] = owner_id
+        sk_body["owner_id"] = owner_id
+    inv = CLIENT.call("POST", "/api/investigations/create", json_body=inv_body)
+    investigation_id = inv["id"]
+    sk_body["investigation_id"] = investigation_id
+    sk = CLIENT.call("POST", "/api/sketches/create", json_body=sk_body)
+    sketch_id = sk["id"]
+
+    prop_key = node_type.lower()
+    client_id = str(uuid.uuid4())
+    add_resp = CLIENT.call(
+        "POST", "/api/sketches/%s/nodes/add" % sketch_id,
+        json_body={"id": client_id, "nodeLabel": seed, "nodeType": node_type,
+                   "nodeMetadata": {}, "nodeProperties": {prop_key: seed},
+                   "x": 100, "y": 100})
+    node_id = client_id
+    if isinstance(add_resp, dict):
+        node = add_resp.get("node") or {}
+        node_id = node.get("id") or add_resp.get("id") or add_resp.get("node_id") or client_id
+
+    launched, launch_errors = [], []
+    for ename in selected:
+        try:
+            CLIENT.call("POST", "/api/enrichers/%s/launch" % urllib.parse.quote(ename),
+                        json_body={"node_ids": [node_id], "sketch_id": sketch_id})
+            launched.append(ename)
+        except ApiError as ex:
+            launch_errors.append({"enricher": ename, "error": str(ex)})
+
+    return {"investigation_id": investigation_id, "sketch_id": sketch_id,
+            "seed": seed, "node_type": node_type, "node_id": node_id,
+            "web_url": "%s/investigations/%s/sketches/%s" % (WEB, investigation_id, sketch_id),
+            "launched_enrichers": launched, "launch_errors": launch_errors,
+            "skipped_forbidden_count": len(skipped),
+            "unknown_only": unknown_only,
+            "non_allowlisted_only": non_allowlisted_only,
+            "note": "Only %s-input allowlisted enrichers were launched. Async: poll flowsint_status." % node_type}
+
+
+def tool_launch_enricher(p):
+    ename = (p.get("enricher") or "").strip()
+    sketch_id = p.get("sketch_id")
+    node_id = p.get("node_id")
+    if not ename or not sketch_id or not node_id:
+        raise ApiError("missing required: enricher, sketch_id, node_id")
+    ok, reason, _ = classify_enricher(ename)
+    if not ok:
+        raise ApiError("enricher rejected: %s (%s)" % (ename, reason))
+    CLIENT.call("POST", "/api/enrichers/%s/launch" % urllib.parse.quote(ename),
+                json_body={"node_ids": [node_id], "sketch_id": sketch_id})
+    return {"enricher": ename, "sketch_id": sketch_id, "node_id": node_id,
+            "status": "launched",
+            "note": "Async: poll flowsint_status(sketch_id) for progress."}
+
+
+def tool_get_graph(p):
+    sketch_id = p["sketch_id"]
+    g = CLIENT.call("GET", "/api/sketches/%s/graph" % sketch_id)
+    return {"sketch_id": sketch_id, **summarize_graph(g if isinstance(g, dict) else {})}
+
+
+def tool_status(p):
+    sketch_id = p["sketch_id"]
+    limit = int(p.get("limit", 50))
+    logs = CLIENT.call("GET", "/api/events/sketch/%s/logs" % sketch_id, query={"limit": limit})
+    items = logs if isinstance(logs, list) else (logs.get("logs") or logs.get("data") or logs)
+    return {"sketch_id": sketch_id, "logs": items}
+
+
+def tool_load_custom_templates_from_disk(p):
+    dir_arg = (p.get("dir") or TEMPLATES_DIR).strip()
+    if not os.path.isdir(dir_arg):
+        raise ApiError("templates dir not found: %s" % dir_arg)
+
+    declared = {e["name"]: e for e in allowlist_templates()}
+    loaded, skipped = [], []
+    files = sorted(glob.glob(os.path.join(dir_arg, "*.yaml"))) + sorted(glob.glob(os.path.join(dir_arg, "*.yml")))
+
+    for path in files:
+        try:
+            with open(path, encoding="utf-8") as fh:
+                body_text = fh.read()
+        except Exception as exc:
+            skipped.append({"path": path, "reason": "read failed: %s" % exc})
+            continue
+        try:
+            import yaml
+            spec = yaml.safe_load(body_text)
+        except Exception as exc:
+            skipped.append({"path": path, "reason": "yaml parse failed: %s" % exc})
+            continue
+        if not isinstance(spec, dict) or not spec.get("name"):
+            skipped.append({"path": path, "reason": "missing 'name' at YAML root"})
+            continue
+        tname = str(spec["name"]).strip()
+        entry = declared.get(tname)
+        if entry is None:
+            skipped.append({"path": path, "name": tname,
+                            "reason": "not declared in allowlist.yaml (default-deny)"})
+            continue
+        ok, reason, _ = classify_enricher(tname)
+        if not ok:
+            skipped.append({"path": path, "name": tname, "reason": "governance denied: %s" % reason})
+            continue
+        payload = {
+            "name": tname,
+            "category": spec.get("category") or (spec.get("input") or {}).get("type") or "Domain",
+            "description": spec.get("description", ""),
+            "version": spec.get("version", 1),
+            "content": spec,
+        }
+        try:
+            CLIENT.call("POST", "/api/enrichers/templates", json_body=payload)
+            loaded.append({"name": tname, "path": path, "source": entry.get("source"),
+                           "action": "created-or-updated"})
+        except ApiError as ex:
+            skipped.append({"path": path, "name": tname, "reason": "API error: %s" % ex})
+
+    return {"dir": dir_arg, "loaded_count": len(loaded), "skipped_count": len(skipped),
+            "loaded": loaded, "skipped": skipped,
+            "note": "Idempotent. Only names declared in allowlist.yaml are pushed to the flowsint API."}
+
+
+def tool_health(_p):
+    api_url = API + "/health"
+    api_status = check_http(api_url)
+
+    celery_status = {"status": "unknown", "note": "no supported /api/workers endpoint yet"}
+    try:
+        raw = CLIENT.call("GET", "/api/workers", timeout=3)
+        workers = raw if isinstance(raw, list) else (raw.get("workers") if isinstance(raw, dict) else None)
+        if workers is not None:
+            celery_status = {"status": "up" if workers else "down", "workers": len(workers)}
+    except ApiError as exc:
+        celery_status = {"status": "unknown", "error": str(exc)[:120]}
+
+    redis_host = ENV.get("REDIS_HOST") or "127.0.0.1"
+    redis_port = int(ENV.get("REDIS_PORT") or 6379)
+    redis_status = check_tcp(redis_host, redis_port)
+
+    neo4j_host = ENV.get("NEO4J_HOST") or "127.0.0.1"
+    neo4j_bolt = int(ENV.get("NEO4J_BOLT_PORT") or 7687)
+    neo4j_status = check_tcp(neo4j_host, neo4j_bolt)
+
+    allow_state = allowlist_state()
+    overall = "up"
+    for st_dict in (api_status, redis_status, neo4j_status):
+        if st_dict.get("status") == "down":
+            overall = "down"
+            break
+        if st_dict.get("status") == "degraded" and overall != "down":
+            overall = "degraded"
+    return {
+        "overall": overall,
+        "api": {"url": api_url, **api_status},
+        "celery": celery_status,
+        "redis": {"host": redis_host, "port": redis_port, **redis_status},
+        "neo4j": {"host": neo4j_host, "bolt_port": neo4j_bolt, **neo4j_status},
+        "allowlist": {"path": allow_state["path"], "entries": allow_state["allowlist_count"],
+                       "error": allow_state["error"]},
+        "otel": otel_bootstrap.stats(),
+        "metrics": metrics.stats(),
+    }
+
+
+TOOLS = {
+    "flowsint_list_enrichers": (
+        tool_list_enrichers,
+        "List LIVE flowsint enrichers filtered by allowlist.yaml (infrastructure-only). Individual/breach/social enrichers are rejected by governance.",
+        {}, []),
+    "flowsint_recon_company": (
+        tool_recon_company,
+        "Governed company-infrastructure recon: create investigation+sketch, seed a domain or organization node, launch only safe infra enrichers, return sketch_id + web_url.",
+        {"seed_domain": {"type": "string"}, "org_name": {"type": "string"},
+         "name": {"type": "string"},
+         "only": {"type": "array", "items": {"type": "string"}}},
+        []),
+    "flowsint_launch_enricher": (
+        tool_launch_enricher,
+        "Launch a SINGLE allowlisted enricher on an existing node.",
+        {"enricher": {"type": "string"}, "sketch_id": {"type": "string"}, "node_id": {"type": "string"}},
+        ["enricher", "sketch_id", "node_id"]),
+    "flowsint_get_graph": (
+        tool_get_graph,
+        "Return the nodes + relationships of a sketch (summarized, truncated at 200).",
+        {"sketch_id": {"type": "string"}}, ["sketch_id"]),
+    "flowsint_status": (
+        tool_status,
+        "Return recent run logs / progress for a sketch.",
+        {"sketch_id": {"type": "string"}, "limit": {"type": "integer"}}, ["sketch_id"]),
+    "flowsint_load_custom_templates_from_disk": (
+        tool_load_custom_templates_from_disk,
+        "Register YAML templates from disk (FLOWSINT_TEMPLATES_DIR) into the flowsint API. Idempotent. Only names declared in allowlist.yaml with source=template are pushed.",
+        {"dir": {"type": "string"}}, []),
+    "flowsint_health": (
+        tool_health,
+        "Return stack health: api, celery, redis, neo4j, allowlist load state, OTel/metrics status.",
+        {}, []),
+}
+
+
+def reply(i, result=None, error=None):
+    m = {"jsonrpc": "2.0", "id": i}
+    if error is not None:
+        m["error"] = {"code": -32000, "message": error}
+    else:
+        m["result"] = result
+    sys.stdout.write(json.dumps(m, ensure_ascii=False) + "\n")
+    sys.stdout.flush()
+
+
+def _dispatch(nm, args):
+    fn, _, _, rq = TOOLS[nm]
+    miss = [r for r in rq if r not in args]
+    if miss:
+        return {"error": "missing: " + ",".join(miss)}
+    with otel_bootstrap.start_span("flowsint.tools." + nm, tool_name=nm):
+        try:
+            out = fn(args)
+            metrics.record_tool_call(nm, "ok")
+            return {"ok": out}
+        except ApiError as e:
+            result = "deny" if "governance" in str(e).lower() else "error"
+            metrics.record_tool_call(nm, result)
+            return {"error": str(e)}
+        except Exception as e:
+            metrics.record_tool_call(nm, "error")
+            return {"error": str(e)}
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except Exception:
+            continue
+        mid, method, params = msg.get("id"), msg.get("method"), msg.get("params") or {}
+        if method == "initialize":
+            reply(mid, {"protocolVersion": params.get("protocolVersion", "2024-11-05"),
+                        "capabilities": {"tools": {}},
+                        "serverInfo": {"name": "transgenia-flowsint", "version": "1.1.0"}})
+        elif method == "tools/list":
+            reply(mid, {"tools": [{"name": n, "description": d,
+                        "inputSchema": {"type": "object", "properties": pr, "required": rq}}
+                        for n, (_, d, pr, rq) in TOOLS.items()]})
+        elif method == "tools/call":
+            nm = params.get("name")
+            args = params.get("arguments") or {}
+            if nm not in TOOLS:
+                reply(mid, error="unknown tool %s" % nm)
+                continue
+            r = _dispatch(nm, args)
+            if "error" in r:
+                reply(mid, {"content": [{"type": "text", "text": "ERROR: %s" % r["error"]}], "isError": True})
+            else:
+                reply(mid, {"content": [{"type": "text", "text": json.dumps(r["ok"], ensure_ascii=False)[:60000]}]})
+        elif mid is not None:
+            reply(mid, {})
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp/metrics.py
+++ b/mcp/metrics.py
@@ -1,0 +1,171 @@
+"""OTel counter for flowsint MCP tool calls, plus optional Prometheus Pushgateway.
+
+Two channels, both opt-in via env:
+  1. OTLP metrics via OpenTelemetry SDK -> any OTLP HTTP receiver (Collector,
+     Langfuse, etc.). Endpoint controlled by OTEL_EXPORTER_OTLP_ENDPOINT.
+  2. Prometheus Pushgateway (PUSHGATEWAY_URL) - fallback for operators who
+     prefer push-based ingestion. Only fires when the env is set.
+
+Both channels degrade to no-op if their dependency is missing or endpoint empty.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+_STATE: dict[str, Any] = {
+    "initialized": False,
+    "otlp_enabled": False,
+    "otlp_counter": None,
+    "pushgateway_url": "",
+    "pushgateway_enabled": False,
+    "service_name": "mcp-flowsint",
+    "reason_disabled": "not-initialized",
+}
+_LOCK = threading.Lock()
+
+
+def _try_otlp_metrics():
+    try:
+        from opentelemetry import metrics  # type: ignore
+        from opentelemetry.sdk.resources import Resource  # type: ignore
+        from opentelemetry.sdk.metrics import MeterProvider  # type: ignore
+        from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader  # type: ignore
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import (  # type: ignore
+            OTLPMetricExporter,
+        )
+        return {
+            "metrics": metrics,
+            "Resource": Resource,
+            "MeterProvider": MeterProvider,
+            "PeriodicExportingMetricReader": PeriodicExportingMetricReader,
+            "OTLPMetricExporter": OTLPMetricExporter,
+        }
+    except ImportError as exc:
+        log.info("metrics: opentelemetry metrics unavailable (%s)", exc)
+        return None
+
+
+def init(force: bool = False) -> dict:
+    """Initialize the counter provider. Idempotent unless force=True."""
+    with _LOCK:
+        if _STATE["initialized"] and not force:
+            return dict(_STATE)
+        _STATE["initialized"] = True
+        _STATE["otlp_enabled"] = False
+        _STATE["pushgateway_enabled"] = False
+        _STATE["reason_disabled"] = ""
+
+        service_name = (os.environ.get("OTEL_SERVICE_NAME") or "mcp-flowsint").strip()
+        _STATE["service_name"] = service_name
+
+        endpoint = (os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT") or "").strip()
+        if endpoint:
+            mods = _try_otlp_metrics()
+            if mods is None:
+                _STATE["reason_disabled"] = "opentelemetry-metrics-not-installed"
+            else:
+                try:
+                    metrics_endpoint = endpoint.rstrip("/")
+                    if not metrics_endpoint.endswith("/v1/metrics"):
+                        metrics_endpoint = metrics_endpoint + "/v1/metrics"
+                    resource = mods["Resource"].create({"service.name": service_name})
+                    exporter = mods["OTLPMetricExporter"](endpoint=metrics_endpoint)
+                    reader = mods["PeriodicExportingMetricReader"](exporter, export_interval_millis=15000)
+                    provider = mods["MeterProvider"](resource=resource, metric_readers=[reader])
+                    mods["metrics"].set_meter_provider(provider)
+                    meter = mods["metrics"].get_meter(service_name)
+                    counter = meter.create_counter(
+                        name="mcp_tool_calls_total",
+                        description="MCP flowsint tool calls by tool and result.",
+                    )
+                    _STATE["otlp_counter"] = counter
+                    _STATE["otlp_enabled"] = True
+                except Exception as exc:
+                    _STATE["reason_disabled"] = "otlp-init-failed:%s" % type(exc).__name__
+                    log.warning("metrics: OTLP init failed: %s", exc)
+        else:
+            _STATE["reason_disabled"] = "OTEL_EXPORTER_OTLP_ENDPOINT-empty"
+
+        pgw = (os.environ.get("PUSHGATEWAY_URL") or "").strip()
+        _STATE["pushgateway_url"] = pgw
+        _STATE["pushgateway_enabled"] = bool(pgw)
+
+        return dict(_STATE)
+
+
+def record_tool_call(tool_name: str, result: str, extra: dict | None = None) -> None:
+    """Increment the counter with (tool, result) labels. No-op if disabled."""
+    counter = _STATE.get("otlp_counter")
+    if counter is not None:
+        attrs = {"tool": tool_name, "result": result}
+        if extra:
+            for k, v in extra.items():
+                if isinstance(v, (str, int, float, bool)) and v is not None:
+                    attrs[k] = v
+        try:
+            counter.add(1, attributes=attrs)
+        except Exception as exc:
+            log.debug("metrics.record_tool_call otlp add failed: %s", exc)
+
+    if _STATE["pushgateway_enabled"]:
+        _push_to_gateway(tool_name, result, extra or {})
+
+
+def _push_to_gateway(tool_name: str, result: str, extra: dict) -> None:
+    """Best-effort push to Prometheus Pushgateway using text-format POST."""
+    url = _STATE["pushgateway_url"].rstrip("/")
+    if not url:
+        return
+    import urllib.parse
+    import urllib.request
+
+    job = _STATE["service_name"]
+    labels = "tool=\"%s\",result=\"%s\"" % (
+        _pgw_escape(tool_name), _pgw_escape(result),
+    )
+    body = "# TYPE mcp_tool_calls_total counter\n"
+    body += "mcp_tool_calls_total{%s} 1\n" % labels
+    endpoint = url + "/metrics/job/" + urllib.parse.quote(job, safe="")
+    req = urllib.request.Request(
+        endpoint,
+        data=body.encode("utf-8"),
+        headers={"Content-Type": "text/plain; version=0.0.4"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=3) as resp:
+            resp.read()
+    except Exception as exc:
+        log.debug("metrics: pushgateway POST failed: %s", exc)
+
+
+def _pgw_escape(v: str) -> str:
+    return (v or "").replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def stats() -> dict:
+    return {
+        "initialized": _STATE["initialized"],
+        "otlp_enabled": _STATE["otlp_enabled"],
+        "pushgateway_enabled": _STATE["pushgateway_enabled"],
+        "pushgateway_url": _STATE["pushgateway_url"],
+        "service_name": _STATE["service_name"],
+        "reason_disabled": _STATE["reason_disabled"],
+    }
+
+
+def _reset_for_tests() -> None:
+    _STATE.update({
+        "initialized": False,
+        "otlp_enabled": False,
+        "otlp_counter": None,
+        "pushgateway_url": "",
+        "pushgateway_enabled": False,
+        "service_name": "mcp-flowsint",
+        "reason_disabled": "reset",
+    })

--- a/mcp/otel_bootstrap.py
+++ b/mcp/otel_bootstrap.py
@@ -1,0 +1,214 @@
+"""OpenTelemetry bootstrap for the flowsint MCP wrapper.
+
+Sends OTLP HTTP spans to any OTLP endpoint (e.g. an OpenTelemetry Collector,
+Langfuse, or a self-hosted receiver). If OTEL_EXPORTER_OTLP_ENDPOINT lacks the
+`/v1/traces` path suffix, it is appended automatically so the operator can
+supply just the base URL.
+
+Env vars (all optional):
+    OTEL_ENABLED                 default "1"; set to "0" to force disable
+    OTEL_SERVICE_NAME            default "mcp-odoo-rpc"
+    OTEL_EXPORTER_OTLP_ENDPOINT  empty = disabled (no spans exported)
+    OTEL_EXPORTER_OTLP_HEADERS   comma-separated k=v pairs
+                                 (e.g. "Authorization=Bearer abc,X-Env=prod")
+    OTEL_TRACES_SAMPLER_ARG      default "1.0" (fraction of traces to keep)
+
+Design:
+- Graceful degrade: if opentelemetry is missing OR endpoint is empty,
+  every helper is a no-op. The MCP keeps running.
+- init() is idempotent — safe to call multiple times.
+- The public API (start_span, is_enabled) is what server.py should touch.
+- No SDK is installed at import time; init() must be called explicitly
+  from the MCP entrypoint so the tests can control the tracer.
+
+Public API:
+    init(force: bool = False) -> bool          # returns True if tracing is live
+    start_span(name: str, **attrs)             # context manager (no-op if disabled)
+    is_enabled() -> bool
+    stats() -> dict
+    _reset_for_tests()                          # test-only
+
+Brain: fase-0-otel-langfuse — real integration gap closed (see plan §2).
+"""
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+from typing import Any, Iterator
+
+log = logging.getLogger(__name__)
+
+_STATE: dict[str, Any] = {
+    "initialized": False,
+    "enabled": False,
+    "endpoint": "",
+    "service_name": "",
+    "provider": None,
+    "tracer": None,
+    "reason_disabled": "not-initialized",
+}
+
+
+def _read_env_flag(name: str, default: str = "1") -> bool:
+    val = (os.environ.get(name, default) or "").strip().lower()
+    return val in ("1", "true", "yes", "on")
+
+
+def _parse_headers(raw: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    if not raw:
+        return out
+    for pair in raw.split(","):
+        pair = pair.strip()
+        if not pair or "=" not in pair:
+            continue
+        k, v = pair.split("=", 1)
+        k = k.strip()
+        v = v.strip()
+        if k:
+            out[k] = v
+    return out
+
+
+def _try_import_otel():
+    try:
+        from opentelemetry import trace  # type: ignore
+        from opentelemetry.sdk.resources import Resource  # type: ignore
+        from opentelemetry.sdk.trace import TracerProvider  # type: ignore
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor  # type: ignore
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (  # type: ignore
+            OTLPSpanExporter,
+        )
+        return {
+            "trace": trace,
+            "Resource": Resource,
+            "TracerProvider": TracerProvider,
+            "BatchSpanProcessor": BatchSpanProcessor,
+            "OTLPSpanExporter": OTLPSpanExporter,
+        }
+    except ImportError as exc:
+        log.info("otel_bootstrap: opentelemetry unavailable (%s) — tracing off", exc)
+        return None
+
+
+def init(force: bool = False) -> bool:
+    """Initialize the tracer provider once. Returns True if tracing is live.
+
+    Called at MCP startup. Safe to call multiple times; a second call is
+    a no-op unless force=True.
+    """
+    if _STATE["initialized"] and not force:
+        return _STATE["enabled"]
+
+    _STATE["initialized"] = True
+    _STATE["enabled"] = False
+    _STATE["reason_disabled"] = ""
+
+    if not _read_env_flag("OTEL_ENABLED", "1"):
+        _STATE["reason_disabled"] = "OTEL_ENABLED=0"
+        return False
+
+    endpoint = (os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "") or "").strip()
+    if not endpoint:
+        _STATE["reason_disabled"] = "OTEL_EXPORTER_OTLP_ENDPOINT-empty"
+        return False
+
+    mods = _try_import_otel()
+    if mods is None:
+        _STATE["reason_disabled"] = "opentelemetry-not-installed"
+        return False
+
+    service_name = (os.environ.get("OTEL_SERVICE_NAME", "") or "mcp-odoo-rpc").strip()
+    headers = _parse_headers(os.environ.get("OTEL_EXPORTER_OTLP_HEADERS", ""))
+
+    try:
+        resource = mods["Resource"].create({"service.name": service_name})
+        provider = mods["TracerProvider"](resource=resource)
+        # OTLP HTTP receivers require the /v1/traces path. Auto-append when the
+        # operator passed only the base (e.g. http://127.0.0.1:4318) so common
+        # collector deployments work without extra env plumbing.
+        traces_endpoint = endpoint.rstrip("/")
+        if not traces_endpoint.endswith("/v1/traces"):
+            traces_endpoint = traces_endpoint + "/v1/traces"
+        exporter = mods["OTLPSpanExporter"](endpoint=traces_endpoint, headers=headers or None)
+        provider.add_span_processor(mods["BatchSpanProcessor"](exporter))
+        mods["trace"].set_tracer_provider(provider)
+        tracer = mods["trace"].get_tracer(service_name)
+    except Exception as exc:  # pragma: no cover - defensive
+        _STATE["reason_disabled"] = f"init-failed:{type(exc).__name__}"
+        log.warning("otel_bootstrap: init failed: %s", exc)
+        return False
+
+    _STATE["enabled"] = True
+    _STATE["endpoint"] = endpoint
+    _STATE["service_name"] = service_name
+    _STATE["provider"] = provider
+    _STATE["tracer"] = tracer
+    log.info(
+        "otel_bootstrap: tracing live service=%s endpoint=%s",
+        service_name, endpoint,
+    )
+    return True
+
+
+@contextlib.contextmanager
+def start_span(name: str, **attributes: Any) -> Iterator[Any]:
+    """Yield a span context. No-op (yields None) if tracing is disabled.
+
+    Attributes must be primitives (str/int/float/bool) or lists thereof —
+    complex objects will silently be dropped by the SDK.
+    """
+    tracer = _STATE.get("tracer")
+    if tracer is None:
+        yield None
+        return
+    span = tracer.start_span(name)
+    try:
+        for k, v in attributes.items():
+            if v is None:
+                continue
+            try:
+                span.set_attribute(k, v)
+            except Exception:
+                # OTel is strict about attribute types; skip silently.
+                pass
+        yield span
+    except Exception as exc:
+        try:
+            span.record_exception(exc)
+            span.set_attribute("error", True)
+            span.set_attribute("error.type", type(exc).__name__)
+        except Exception:
+            pass
+        raise
+    finally:
+        try:
+            span.end()
+        except Exception:
+            pass
+
+
+def is_enabled() -> bool:
+    return bool(_STATE.get("enabled"))
+
+
+def stats() -> dict:
+    return {
+        "initialized": _STATE["initialized"],
+        "enabled": _STATE["enabled"],
+        "service_name": _STATE["service_name"],
+        "endpoint": _STATE["endpoint"],
+        "reason_disabled": _STATE["reason_disabled"],
+    }
+
+
+def _reset_for_tests() -> None:
+    """Test-only: wipe the tracer state so init() can re-run."""
+    _STATE["initialized"] = False
+    _STATE["enabled"] = False
+    _STATE["endpoint"] = ""
+    _STATE["service_name"] = ""
+    _STATE["provider"] = None
+    _STATE["tracer"] = None
+    _STATE["reason_disabled"] = "reset"


### PR DESCRIPTION
Adds a Python stdlib+PyYAML MCP (Model Context Protocol) wrapper under `mcp/` that lets an LLM assistant drive company-infrastructure recon safely under a data-driven governance model.