### PR TITLE
feat(ci): add manual release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+# Bump all package/pyproject versions, update CHANGELOG.md, commit, tag and
+# push to main. The tag push then triggers images.yml (build + push Docker
+# images) exactly like a manual `git push --follow-tags` would.
+#
+# Requires a PAT stored as the GH_PAT secret: pushes made with the default
+# GITHUB_TOKEN don't trigger other workflows (GitHub anti-loop policy), so
+# a plain checkout token here would silently skip the images.yml build.
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type"
+        required: true
+        type: choice
+        options: [patch, minor, major, custom]
+        default: patch
+      custom_version:
+        description: "Custom version (e.g. 2.1.0) - only used when bump=custom"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Bump version, tag and push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version, update changelog, commit and tag
+        run: |
+          if [ "${{ inputs.bump }}" = "custom" ]; then
+            RELEASE_AS="${{ inputs.custom_version }}"
+          else
+            RELEASE_AS="${{ inputs.bump }}"
+          fi
+          yarn release -- --release-as "$RELEASE_AS"
+
+      - name: Push commit and tag
+        run: git push origin main --follow-tags

--- a/flowsint-api/pyproject.toml
+++ b/flowsint-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flowsint-api"
-version = "1.2.8"
+version = "1.2.11"
 description = "API server for flowsint"
 license = "Apache-2.0"
 authors = [{ name = "dextmorgn", email = "contact@flowsint.io" }]

--- a/flowsint-app/package.json
+++ b/flowsint-app/package.json
@@ -2,7 +2,7 @@
   "name": "flowsint-app",
   "productName": "Flowsint",
   "license": "Apache-2.0",
-  "version": "1.0.0",
+  "version": "1.2.11",
   "type": "module",
   "description": "Graph analysis and intelligence platform to help you discover hidden relationships and insights.",
   "author": "DexterMorgan",

--- a/flowsint-core/pyproject.toml
+++ b/flowsint-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flowsint-core"
-version = "1.2.8"
+version = "1.2.11"
 description = "Core utilities and base classes for flowsint modules"
 authors = [{ name = "dextmorgn", email = "contact@flowsint.io" }]
 requires-python = ">=3.12,<4.0"

--- a/flowsint-enrichers/pyproject.toml
+++ b/flowsint-enrichers/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flowsint-enrichers"
-version = "1.2.8"
+version = "1.2.11"
 description = "Enricher modules for flowsint"
 license = "Apache-2.0"
 authors = [{ name = "dextmorgn", email = "contact@flowsint.io" }]

--- a/flowsint-types/pyproject.toml
+++ b/flowsint-types/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flowsint-types"
-version = "1.2.8"
+version = "1.2.11"
 description = "Pydantic models for flowsint"
 license = "Apache-2.0"
 authors = [{ name = "dextmorgn", email = "contact@flowsint.io" }]

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "@commitlint/cli": "^20.1.0",
     "@commitlint/config-conventional": "^20.0.0",
     "commitizen": "^4.3.1",
-    "cz-conventional-changelog": "^3.3.0"
+    "cz-conventional-changelog": "^3.3.0",
+    "standard-version": "^9.5.0"
   },
   "workspaces": [
     "flowsint-app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flowsint"
-version = "1.2.8"
+version = "1.2.11"
 description = "Flowsint multi-module project"
 authors = [{ name = "dextmorgn", email = "contact@flowsint.io" }]
 requires-python = ">=3.12,<4.0"

--- a/scripts/sync-versions.js
+++ b/scripts/sync-versions.js
@@ -4,7 +4,7 @@
  * Version Synchronization Script
  *
  * Keeps versions synchronized across:
- * - pyproject.toml (root)
+ * - pyproject.toml (root + every uv workspace member)
  * - flowsint-app/package.json
  *
  * Usage: node scripts/sync-versions.js <new-version>
@@ -18,8 +18,19 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const ROOT_DIR = join(__dirname, '..');
 
-function updatePyprojectVersion(version) {
-  const pyprojectPath = join(ROOT_DIR, 'pyproject.toml');
+// Root pyproject.toml + every [tool.uv.workspace] member (kept in lockstep
+// with the root version since they're path deps of one shipped project, not
+// independently published packages).
+const PYPROJECT_DIRS = [
+  '.',
+  'flowsint-api',
+  'flowsint-core',
+  'flowsint-enrichers',
+  'flowsint-types',
+];
+
+function updatePyprojectVersion(dir, version) {
+  const pyprojectPath = join(ROOT_DIR, dir, 'pyproject.toml');
   let content = readFileSync(pyprojectPath, 'utf8');
 
   // Update version in [project] section
@@ -29,7 +40,7 @@ function updatePyprojectVersion(version) {
   );
 
   writeFileSync(pyprojectPath, content, 'utf8');
-  console.log(`✓ Updated pyproject.toml to ${version}`);
+  console.log(`✓ Updated ${dir}/pyproject.toml to ${version}`);
 }
 
 function updatePackageJsonVersion(version) {
@@ -65,7 +76,9 @@ if (!/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(newVersion)) {
 }
 
 try {
-  updatePyprojectVersion(newVersion);
+  for (const dir of PYPROJECT_DIRS) {
+    updatePyprojectVersion(dir, newVersion);
+  }
   updatePackageJsonVersion(newVersion);
   console.log(`\n✓ All versions synchronized to ${newVersion}`);
 } catch (error) {


### PR DESCRIPTION
## Summary
- `workflow_dispatch` button (patch/minor/major/custom) to bump version, update CHANGELOG, tag and push, reusing `yarn release` / `standard-version` / `sync-versions.js` instead of duplicating bump logic in YAML — tag push then triggers `images.yml` as-is.
- Fixed version drift: `flowsint-app/package.json` was stuck at `1.0.0`, root `pyproject.toml` at `1.2.8`, both behind the actual `v1.2.11` tag — would have tagged `v1.0.1` next (semver regression, broken Docker tags).
- `sync-versions.js` now also bumps the 4 workspace `pyproject.toml` (api/core/enrichers/types), not just root + `flowsint-app`.

## Test plan
- [ ] Add `GH_PAT` secret
- [ ] Run workflow manually with `bump: patch`, confirm commit/tag/push + `images.yml` triggers