### PR TITLE
feat(core): add nmap XML import support

### DIFF
--- a/flowsint-api/app/api/routes/sketches.py
+++ b/flowsint-api/app/api/routes/sketches.py
@@ -411,7 +411,7 @@ async def analyze_import_file(
     db: Session = Depends(get_db),
     current_user: Profile = Depends(get_current_user),
 ):
-    """Analyze an uploaded TXT or JSON file for import."""
+    """Analyze an uploaded TXT, JSON or nmap XML file for import."""
     service = create_sketch_service(db)
     try:
         service.get_by_id(UUID(sketch_id), current_user.id)
@@ -420,10 +420,12 @@ async def analyze_import_file(
     except PermissionDeniedError:
         raise HTTPException(status_code=403, detail="Forbidden")
 
-    if not file.filename or not file.filename.lower().endswith((".txt", ".json")):
+    if not file.filename or not file.filename.lower().endswith(
+        (".txt", ".json", ".xml")
+    ):
         raise HTTPException(
             status_code=400,
-            detail="Only .txt and .json files are supported. Please upload a correct format.",
+            detail="Only .txt, .json and .xml files are supported. Please upload a correct format.",
         )
 
     try:

--- a/flowsint-app/src/components/sketches/import-sheet.tsx
+++ b/flowsint-app/src/components/sketches/import-sheet.tsx
@@ -19,7 +19,7 @@ interface ImportSheetProps {
   sketchId: string
 }
 
-const ALLOWED_EXTENSIONS = ['.txt', '.json']
+const ALLOWED_EXTENSIONS = ['.txt', '.json', '.xml']
 
 export function ImportSheet({ sketchId }: ImportSheetProps) {
   const onOpenChange = useGraphSettingsStore((s) => s.setImportModalOpen)
@@ -120,7 +120,8 @@ export function ImportSheet({ sketchId }: ImportSheetProps) {
         <SheetHeader className="shrink-0 border-b bg-background p-0 h-19 px-6 justify-center flex-col flex items-start">
           <SheetTitle>Import entities</SheetTitle>
           <SheetDescription>
-            Upload a TXT file with one value per line to import entities into your sketch
+            Upload a TXT file with one value per line, a JSON graph, or an nmap XML report to
+            import entities into your sketch
           </SheetDescription>
         </SheetHeader>
         <div className="flex flex-col grow overflow-hidden p-6">
@@ -155,9 +156,9 @@ export function ImportSheet({ sketchId }: ImportSheetProps) {
                   </label>
                 </Button>
                 <p className="text-xs text-muted-foreground">
-                  Supported format:{' '}
-                  <span className="font-bold">{ALLOWED_EXTENSIONS.join(', ')}</span> (one value per
-                  line)
+                  Supported formats:{' '}
+                  <span className="font-bold">{ALLOWED_EXTENSIONS.join(', ')}</span> (.xml must be
+                  an nmap report)
                 </p>
               </div>
             </div>

--- a/flowsint-core/pyproject.toml
+++ b/flowsint-core/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "pytest>=9.0.3,<10.0.0",
     "cryptography>=48.0.1,<49.0.0",
     "openpyxl>=3.1,<4.0",
+    "defusedxml>=0.7,<0.8",
 ]
 
 [dependency-groups]

--- a/flowsint-core/src/flowsint_core/imports/file_parser.py
+++ b/flowsint-core/src/flowsint_core/imports/file_parser.py
@@ -1,7 +1,7 @@
 """
 File parsing utilities for entity imports.
-Handles TXT file format only.
-Each line represents ONE entity with a single value.
+Handles TXT, JSON and nmap XML file formats.
+In a TXT file each line represents ONE entity with a single value.
 """
 
 from pathlib import Path
@@ -10,10 +10,11 @@ from typing import BinaryIO, Optional, Union
 from flowsint_core.core.graph.serializer import TypeResolver
 
 from .json import parse_json
+from .nmap import parse_nmap
 from .txt import parse_txt
 from .types import FileParseResult
 
-ALLOWED_EXTENSIONS = [".txt", ".json"]
+ALLOWED_EXTENSIONS = [".txt", ".json", ".xml"]
 
 
 def parse_import_file(
@@ -44,3 +45,5 @@ def parse_import_file(
         return parse_txt(file_bytes, max_preview_rows)
     elif file_ext in [".json"]:
         return parse_json(file_bytes, max_preview_rows, type_resolver=type_resolver)
+    elif file_ext == ".xml":
+        return parse_nmap(file_bytes, max_preview_rows)

--- a/flowsint-core/src/flowsint_core/imports/nmap/__init__.py
+++ b/flowsint-core/src/flowsint_core/imports/nmap/__init__.py
@@ -1,0 +1,5 @@
+from .parse_nmap import parse_nmap
+
+__all__ = [
+    "parse_nmap",
+]

--- a/flowsint-core/src/flowsint_core/imports/nmap/parse_nmap.py
+++ b/flowsint-core/src/flowsint_core/imports/nmap/parse_nmap.py
@@ -1,0 +1,282 @@
+"""Parse an nmap XML report (`nmap -oX`) into hosts, hostnames and ports.
+
+Produces:
+- one Ip per host reported up
+- one Domain per <hostname>, linked REVERSE_RESOLVES_TO for a PTR record and
+  RESOLVES_TO for a name given on the command line
+- one Port per <port> element, linked HAS_PORT from its host
+
+Port state is carried through verbatim, so filtered stays distinguishable from
+closed, and banner is only set when nmap fingerprinted the service.
+
+Hosts reported down and <extraports> summaries are skipped: neither carries a
+per-port result. A host with no <status> element is treated as up, since tools
+that reuse nmap's format do not always write one.
+"""
+
+import re
+from typing import Dict, Iterator, List, Optional, Tuple
+from xml.etree.ElementTree import Element, ParseError
+
+from defusedxml.common import DefusedXmlException
+from defusedxml.ElementTree import fromstring
+from flowsint_types import Domain, Ip, Port
+
+from ..types import Edge, Entity, EntityPreview, FileParseResult
+
+# A bound on how much is parsed into memory as a DOM.
+MAX_FILE_BYTES = 32 * 1024 * 1024
+
+# Service names and banners are whatever the remote host chose to send back.
+_CONTROL_CHARACTERS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+MAX_TEXT_LENGTH = 512
+
+# nmap -sO reports IP protocol numbers in portid, which are not port numbers.
+PORT_PROTOCOLS = ("tcp", "udp", "sctp")
+
+
+def parse_nmap(
+    file_bytes: bytes,
+    max_preview_rows: int,
+) -> FileParseResult:
+    """Parse an nmap XML report into hosts, hostnames and ports."""
+    root = _parse_xml(file_bytes)
+
+    hosts = root.findall("host")
+    if not hosts:
+        raise ValueError(
+            "This is a valid nmap report but it contains no <host> element, "
+            "so there is nothing to import."
+        )
+
+    previews: Dict[str, EntityPreview] = {}
+    edges: List[Edge] = []
+
+    def add(node_id: str, obj) -> bool:
+        """Record an entity once. False means the preview limit was reached."""
+        if node_id in previews:
+            return True
+        if len(previews) >= max_preview_rows:
+            return False
+        previews[node_id] = EntityPreview(
+            obj=obj,
+            detected_type=type(obj).__name__,
+            node_id=node_id,
+        )
+        return True
+
+    def link(from_id: str, to_id: str, label: str) -> None:
+        """Link two entities, but only if both survived the preview limit."""
+        source = previews.get(from_id)
+        target = previews.get(to_id)
+        if source is None or target is None:
+            return
+        edges.append(
+            Edge(
+                from_obj=source.obj,
+                from_id=from_id,
+                to_obj=target.obj,
+                to_id=to_id,
+                label=label,
+            )
+        )
+
+    for host in hosts:
+        if not _is_up(host):
+            continue
+
+        address = _host_address(host)
+        if address is None:
+            continue
+        try:
+            ip = Ip(address=address)
+        except ValueError:
+            continue
+
+        ip_id = f"ip:{address}"
+        if not add(ip_id, ip):
+            break
+
+        for hostname, is_ptr in _hostnames(host):
+            try:
+                domain = Domain(domain=hostname)
+            except ValueError:
+                # nmap resolves names that are not domains -- localhost, a bare
+                # NetBIOS name, a name with an underscore. Skip those rather
+                # than fail the whole import.
+                continue
+            domain_id = f"domain:{hostname}"
+            if not add(domain_id, domain):
+                break
+            if is_ptr:
+                link(ip_id, domain_id, "REVERSE_RESOLVES_TO")
+            else:
+                link(domain_id, ip_id, "RESOLVES_TO")
+
+        for port in _ports(host):
+            port_id = f"port:{address}:{port.protocol}:{port.number}"
+            if not add(port_id, port):
+                break
+            link(ip_id, port_id, "HAS_PORT")
+
+    entities: Dict[str, Entity] = {}
+    for preview in previews.values():
+        if preview.detected_type in entities:
+            entities[preview.detected_type].results.append(preview)
+        else:
+            entities[preview.detected_type] = Entity(
+                type=preview.detected_type, results=[preview]
+            )
+
+    return FileParseResult(
+        entities=entities,
+        edges=edges,
+        total_entities=len(previews),
+    )
+
+
+def _parse_xml(file_bytes: Optional[bytes]) -> Element:
+    """Turn the uploaded bytes into an <nmaprun> element, or explain why not."""
+    if not file_bytes or not file_bytes.strip():
+        raise ValueError("File is empty")
+
+    if len(file_bytes) > MAX_FILE_BYTES:
+        raise ValueError(
+            f"nmap report is larger than {MAX_FILE_BYTES // (1024 * 1024)} MB "
+            "and was not parsed."
+        )
+
+    try:
+        # An uploaded report is untrusted, and so are the service banners inside
+        # it. defusedxml refuses entity declarations and external references in
+        # the parser, so the refusal holds whatever encoding the file declares.
+        # DTDs are not forbidden outright because nmap writes <!DOCTYPE nmaprun>.
+        # Bytes rather than str: the document carries its own encoding
+        # declaration and the parser is the right thing to honour it.
+        root = fromstring(file_bytes)
+    except (ParseError, LookupError) as e:
+        raise ValueError(f"Invalid XML: {str(e)}")
+    except DefusedXmlException as e:
+        raise ValueError(
+            f"This XML uses a feature that is refused when parsing an untrusted "
+            f"file ({type(e).__name__}). nmap does not produce such a report."
+        )
+
+    if root.tag != "nmaprun":
+        raise ValueError(
+            f"Not an nmap report: expected a <nmaprun> root element, found "
+            f"<{root.tag}>."
+        )
+    return root
+
+
+def _is_up(host: Element) -> bool:
+    """Whether nmap found the host up, and so actually scanned its ports."""
+    status = host.find("status")
+    if status is None:
+        # Tools that reuse nmap's format do not always write <status>.
+        return True
+    return (status.get("state") or "").lower() == "up"
+
+
+def _host_address(host: Element) -> Optional[str]:
+    """The host's first IPv4 or IPv6 address. MAC addresses are not hosts."""
+    for address in host.findall("address"):
+        if (address.get("addrtype") or "").startswith("ipv"):
+            value = address.get("addr")
+            if value:
+                return value.strip()
+    return None
+
+
+def _hostnames(host: Element) -> Iterator[Tuple[str, bool]]:
+    """Each name nmap has for the host, and whether it came from a PTR record."""
+    container = host.find("hostnames")
+    if container is None:
+        return
+    seen = set()
+    for hostname in container.findall("hostname"):
+        name = (hostname.get("name") or "").strip().lower()
+        if not name:
+            continue
+        # type="PTR" is a reverse lookup nmap did; type="user" is the name given
+        # on the command line, which resolved forward to this address. nmap
+        # reports both when they agree, so the pair is what is de-duplicated.
+        is_ptr = (hostname.get("type") or "").upper() == "PTR"
+        if (name, is_ptr) in seen:
+            continue
+        seen.add((name, is_ptr))
+        yield name, is_ptr
+
+
+def _ports(host: Element) -> Iterator[Port]:
+    """Each port nmap reported an individual result for."""
+    container = host.find("ports")
+    if container is None:
+        return
+    for element in container.findall("port"):
+        protocol = (element.get("protocol") or "tcp").lower()
+        if protocol not in PORT_PROTOCOLS:
+            continue
+
+        portid = element.get("portid")
+        if portid is None:
+            continue
+        try:
+            number = int(portid)
+        except ValueError:
+            continue
+
+        state_element = element.find("state")
+        state = state_element.get("state") if state_element is not None else None
+        service, banner = _service(element)
+
+        try:
+            yield Port(
+                number=number,
+                # Upper case to match the Port nodes the naabu enricher creates,
+                # since the protocol is part of the node label.
+                protocol=protocol.upper(),
+                state=state or None,
+                service=service,
+                banner=banner,
+            )
+        except ValueError:
+            # A port number outside 0-65535 is not a port. Skip the row.
+            continue
+
+
+def _service(port: Element) -> Tuple[Optional[str], Optional[str]]:
+    """The service name, and the banner only if nmap really read one."""
+    service = port.find("service")
+    if service is None:
+        return None, None
+
+    name = _clean(service.get("name"))
+    # nmap prints a TLS-wrapped service as ssl/http rather than http, and the
+    # difference between a cleartext and an encrypted service is worth keeping.
+    if name and (service.get("tunnel") or "").lower() == "ssl":
+        name = f"ssl/{name}"
+
+    # nmap records how it decided: "probed" means it fingerprinted the service
+    # (-sV), anything else means it looked the port number up in nmap-services
+    # and guessed. product/version/extrainfo only exist in the probed case.
+    if (service.get("method") or "table").lower() != "probed":
+        # Tools that reuse nmap's format write no method but do write a banner.
+        return name, _clean(service.get("banner"))
+
+    parts = [
+        _clean(service.get("product")),
+        _clean(service.get("version")),
+        _clean(service.get("extrainfo")),
+    ]
+    banner = " ".join(part for part in parts if part).strip()
+    return name, banner[:MAX_TEXT_LENGTH] or None
+
+
+def _clean(value: Optional[str]) -> Optional[str]:
+    """Strip control characters out of remote-controlled text, and bound it."""
+    if not value:
+        return None
+    cleaned = _CONTROL_CHARACTERS.sub("", value).strip()
+    return cleaned[:MAX_TEXT_LENGTH] or None

--- a/flowsint-core/tests/import/nmap/test_nmap_import.py
+++ b/flowsint-core/tests/import/nmap/test_nmap_import.py
@@ -1,0 +1,637 @@
+"""Comprehensive tests for nmap XML import functionality.
+
+Tests parsing of nmap reports into hosts, hostnames and ports. Every report
+below is a canned fixture; no scan was run to produce them.
+"""
+
+import pytest
+from flowsint_types import Domain, Ip, Port
+
+from flowsint_core.imports import parse_import_file
+from flowsint_core.imports.nmap.parse_nmap import (
+    MAX_FILE_BYTES,
+    MAX_TEXT_LENGTH,
+    parse_nmap,
+)
+
+# An `nmap -sV` report against nmap's own public scan-permission host. One host
+# up, a scanned name and a differing PTR name, a probed service, a service
+# guessed from the port number, a filtered port and a closed port.
+scanme_report = b"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE nmaprun>
+<?xml-stylesheet href="file:///usr/local/share/nmap/nmap.xsl" type="text/xsl"?>
+<nmaprun scanner="nmap" args="nmap -sV -oX scan.xml scanme.nmap.org" start="1735689600" startstr="Wed Jan  1 00:00:00 2025" version="7.94" xmloutputversion="1.05">
+<scaninfo type="connect" protocol="tcp" numservices="1000" services="1-1000"/>
+<verbose level="0"/>
+<debugging level="0"/>
+<host starttime="1735689600" endtime="1735689610">
+<status state="up" reason="conn-refused" reason_ttl="0"/>
+<address addr="45.33.32.156" addrtype="ipv4"/>
+<hostnames>
+<hostname name="scanme.nmap.org" type="user"/>
+<hostname name="li982-156.members.linode.com" type="PTR"/>
+</hostnames>
+<ports>
+<extraports state="filtered" count="996">
+<extrareasons reason="no-response" count="996"/>
+</extraports>
+<port protocol="tcp" portid="22"><state state="open" reason="conn-refused" reason_ttl="0"/><service name="ssh" product="OpenSSH" version="6.6.1p1 Ubuntu 2ubuntu2.13" extrainfo="Ubuntu Linux; protocol 2.0" method="probed" conf="10"><cpe>cpe:/a:openbsd:openssh:6.6.1p1</cpe></service></port>
+<port protocol="tcp" portid="25"><state state="closed" reason="conn-refused" reason_ttl="0"/></port>
+<port protocol="tcp" portid="80"><state state="open" reason="syn-ack" reason_ttl="0"/><service name="http" product="Apache httpd" version="2.4.7" method="table" conf="3"/></port>
+<port protocol="tcp" portid="443"><state state="filtered" reason="no-response" reason_ttl="0"/></port>
+</ports>
+<times srtt="120000" rttvar="30000" to="240000"/>
+</host>
+<runstats><finished time="1735689610" timestr="Wed Jan  1 00:00:10 2025" elapsed="10.00" exit="success"/><hosts up="1" down="0" total="1"/></runstats>
+</nmaprun>
+"""
+
+# Two hosts that are both up and share a port number, plus one that is down.
+subnet_report = b"""<?xml version="1.0" encoding="UTF-8"?>
+<nmaprun scanner="nmap" args="nmap -oX scan.xml 10.0.0.0/29" start="1735689600" version="7.94">
+<host>
+<status state="up" reason="syn-ack" reason_ttl="64"/>
+<address addr="10.0.0.1" addrtype="ipv4"/>
+<ports>
+<port protocol="tcp" portid="80"><state state="open" reason="syn-ack"/><service name="http" product="nginx" version="1.18.0" method="probed"/></port>
+</ports>
+</host>
+<host>
+<status state="up" reason="syn-ack" reason_ttl="64"/>
+<address addr="10.0.0.2" addrtype="ipv4"/>
+<ports>
+<port protocol="tcp" portid="53"><state state="open" reason="syn-ack"/></port>
+<port protocol="udp" portid="53"><state state="open" reason="udp-response"/></port>
+</ports>
+</host>
+<host>
+<status state="down" reason="no-response"/>
+<address addr="10.0.0.3" addrtype="ipv4"/>
+</host>
+</nmaprun>
+"""
+
+# A link-local host, where nmap reports a MAC address alongside the IP.
+local_report = b"""<?xml version="1.0" encoding="UTF-8"?>
+<nmaprun scanner="nmap" args="nmap -oX scan.xml 192.168.1.0/24" start="1735689600" version="7.94">
+<host>
+<status state="up" reason="arp-response"/>
+<address addr="00:0C:29:AB:CD:EF" addrtype="mac" vendor="VMware"/>
+<address addr="192.168.1.10" addrtype="ipv4"/>
+<ports>
+<port protocol="tcp" portid="443"><state state="open" reason="syn-ack"/><service name="http" tunnel="ssl" product="nginx" method="probed"/></port>
+</ports>
+</host>
+</nmaprun>
+"""
+
+# An IPv6 host.
+ipv6_report = b"""<?xml version="1.0" encoding="UTF-8"?>
+<nmaprun scanner="nmap" args="nmap -6 -sU -oX scan.xml" start="1735689600" version="7.94">
+<host>
+<status state="up" reason="syn-ack"/>
+<address addr="2606:2800:220:1:248:1893:25c8:1946" addrtype="ipv6"/>
+<ports>
+<port protocol="udp" portid="53"><state state="open" reason="udp-response"/><service name="domain" method="table"/></port>
+</ports>
+</host>
+</nmaprun>
+"""
+
+# The shape another tool emits: no <status>, no <hostnames>, no method, and the
+# service text in a banner attribute.
+converted_report = b"""<?xml version="1.0" encoding="UTF-8"?>
+<nmaprun scanner="masscan" args="masscan --output-format xml" start="1735689600">
+<host>
+<address addr="192.168.1.20" addrtype="ipv4"/>
+<ports>
+<port protocol="tcp" portid="8080"><service name="http" banner="HTTP/1.0 200 OK"/></port>
+</ports>
+</host>
+</nmaprun>
+"""
+
+
+class TestBasicNmapParsing:
+    """Tests for parsing a normal nmap report."""
+
+    def test_host_becomes_an_ip(self):
+        """Test that the scanned host is imported as an Ip entity."""
+        result = parse_nmap(scanme_report, max_preview_rows=100)
+
+        assert "Ip" in result.entities
+        ips = result.entities["Ip"].results
+        assert len(ips) == 1
+        assert isinstance(ips[0].obj, Ip)
+        assert ips[0].obj.address == "45.33.32.156"
+
+    def test_every_port_element_is_imported(self):
+        """Test that all four <port> elements become Port entities."""
+        result = parse_nmap(scanme_report, max_preview_rows=100)
+
+        ports = result.entities["Port"].results
+        assert len(ports) == 4
+        assert {port.obj.number for port in ports} == {22, 25, 80, 443}
+        assert all(isinstance(port.obj, Port) for port in ports)
+
+    def test_hostnames_become_domains(self):
+        """Test that each hostname record becomes a Domain entity."""
+        result = parse_nmap(scanme_report, max_preview_rows=100)
+
+        domains = result.entities["Domain"].results
+        assert {domain.obj.domain for domain in domains} == {
+            "scanme.nmap.org",
+            "li982-156.members.linode.com",
+        }
+        assert all(isinstance(domain.obj, Domain) for domain in domains)
+
+    def test_total_entities_counts_every_entity(self):
+        """Test that total_entities is 1 Ip + 2 Domains + 4 Ports."""
+        result = parse_nmap(scanme_report, max_preview_rows=100)
+
+        assert result.total_entities == 7
+
+    def test_every_entity_has_a_node_id(self):
+        """Test that entities carry a node_id, without which edges are dropped."""
+        result = parse_nmap(scanme_report, max_preview_rows=100)
+
+        for entity in result.entities.values():
+            for preview in entity.results:
+                assert preview.node_id
+
+
+class TestPortState:
+    """Tests that a port's state survives the import verbatim."""
+
+    def test_states_are_not_flattened(self):
+        """Test that open, closed and filtered are kept apart."""
+        result = parse_nmap(scanme_report, max_preview_rows=100)
+
+        states = {
+            port.obj.number: port.obj.state for port in result.entities["Port"].results
+        }
+        assert states[22] == "open"
+        assert states[80] == "open"
+        assert states[443] == "filtered"
+        assert states[25] == "closed"
+
+    def test_protocol_is_read_from_the_report(self):
+        """Test that a UDP result is not defaulted to TCP."""
+        result = parse_nmap(ipv6_report, max_preview_rows=100)
+
+        assert result.entities["Port"].results[0].obj.protocol == "UDP"
+
+    def test_protocol_case_matches_the_naabu_enricher(self):
+        """Test that protocol is upper case, since it is part of the node label."""
+        result = parse_nmap(scanme_report, max_preview_rows=100)
+
+        port = result.entities["Port"].results[0].obj
+        assert port.protocol == "TCP"
+        assert "(TCP)" in port.nodeLabel
+
+    def test_missing_state_element_leaves_state_unset(self):
+        """Test that a port with no <state> child does not get an invented one."""
+        result = parse_nmap(converted_report, max_preview_rows=100)
+
+        port = result.entities["Port"].results[0].obj
+        assert port.number == 8080
+        assert port.state is None
+
+    def test_ip_protocol_scan_is_not_imported_as_ports(self):
+        """Test that nmap -sO protocol numbers are not mistaken for port numbers."""
+        report = scanme_report.replace(
+            b'protocol="tcp" portid="22"', b'protocol="ip" portid="1"'
+        )
+
+        result = parse_nmap(report, max_preview_rows=100)
+
+        assert {p.obj.number for p in result.entities["Port"].results} == {25, 80, 443}
+
+
+class TestServiceDetection:
+    """Tests for the probed/guessed distinction on service names."""
+
+    def test_probed_service_carries_a_banner(self):
+        """Test that a fingerprinted service keeps its product and version."""
+        result = parse_nmap(scanme_report, max_preview_rows=100)
+
+        ssh = next(p.obj for p in result.entities["Port"].results if p.obj.number == 22)
+        assert ssh.service == "ssh"
+        assert (
+            ssh.banner
+            == "OpenSSH 6.6.1p1 Ubuntu 2ubuntu2.13 Ubuntu Linux; protocol 2.0"
+        )
+
+    def test_guessed_service_has_no_banner(self):
+        """Test that a service named from the port number is not given a banner.
+
+        The fixture's port 80 carries a product and version alongside
+        method="table", which nmap does not do, precisely so that this asserts
+        the method gate rather than the absence of the fields.
+        """
+        result = parse_nmap(scanme_report, max_preview_rows=100)
+
+        http = next(
+            p.obj for p in result.entities["Port"].results if p.obj.number == 80
+        )
+        assert http.service == "http"
+        assert http.banner is None
+
+    def test_port_without_a_service_element(self):
+        """Test that a port nmap could not name has no service and no banner."""
+        result = parse_nmap(scanme_report, max_preview_rows=100)
+
+        filtered = next(
+            p.obj for p in result.entities["Port"].results if p.obj.number == 443
+        )
+        assert filtered.service is None
+        assert filtered.banner is None
+
+    def test_tls_wrapped_service_is_distinguishable(self):
+        """Test that an SSL-tunnelled service does not import as cleartext."""
+        result = parse_nmap(local_report, max_preview_rows=100)
+
+        port = result.entities["Port"].results[0].obj
+        assert port.service == "ssl/http"
+
+    def test_banner_attribute_is_read_when_there_is_no_method(self):
+        """Test that a converted report's banner attribute is not dropped."""
+        result = parse_nmap(converted_report, max_preview_rows=100)
+
+        assert result.entities["Port"].results[0].obj.banner == "HTTP/1.0 200 OK"
+
+    def test_control_characters_are_stripped_from_banners(self):
+        """Test that control characters do not survive into a banner.
+
+        DEL is used because it is a control character that is also a legal XML
+        1.0 character, so it survives the parser and reaches the banner.
+        """
+        report = scanme_report.replace(b'product="OpenSSH"', b'product="Open\x7fSSH"')
+
+        result = parse_nmap(report, max_preview_rows=100)
+
+        ssh = next(p.obj for p in result.entities["Port"].results if p.obj.number == 22)
+        assert "\x7f" not in ssh.banner
+        assert ssh.banner.startswith("OpenSSH")
+
+    def test_service_name_is_bounded(self):
+        """Test that a remote host cannot choose the length of a graph label."""
+        report = scanme_report.replace(b'name="ssh"', b'name="' + b"A" * 5000 + b'"')
+
+        result = parse_nmap(report, max_preview_rows=100)
+
+        ssh = next(p.obj for p in result.entities["Port"].results if p.obj.number == 22)
+        assert len(ssh.service) == MAX_TEXT_LENGTH
+
+    def test_banner_is_bounded(self):
+        """Test that the joined product, version and extrainfo are bounded."""
+        long_value = b"B" * 400
+        report = scanme_report.replace(
+            b'product="OpenSSH"', b'product="' + long_value + b'"'
+        )
+        report = report.replace(
+            b'version="6.6.1p1 Ubuntu 2ubuntu2.13"', b'version="' + long_value + b'"'
+        )
+        report = report.replace(
+            b'extrainfo="Ubuntu Linux; protocol 2.0"',
+            b'extrainfo="' + long_value + b'"',
+        )
+
+        result = parse_nmap(report, max_preview_rows=100)
+
+        ssh = next(p.obj for p in result.entities["Port"].results if p.obj.number == 22)
+        assert len(ssh.banner) == MAX_TEXT_LENGTH
+
+
+class TestEdges:
+    """Tests for the relationships an nmap report implies."""
+
+    def test_every_port_is_linked_to_its_host(self):
+        """Test that each Port gets a HAS_PORT edge from its host."""
+        result = parse_nmap(scanme_report, max_preview_rows=100)
+
+        has_port = [edge for edge in result.edges if edge.label == "HAS_PORT"]
+        assert len(has_port) == 4
+        assert all(edge.from_id == "ip:45.33.32.156" for edge in has_port)
+
+    def test_ptr_and_user_hostnames_get_opposite_edges(self):
+        """Test that a PTR record resolves backwards and a scanned name forwards."""
+        result = parse_nmap(scanme_report, max_preview_rows=100)
+
+        reverse = next(e for e in result.edges if e.label == "REVERSE_RESOLVES_TO")
+        assert reverse.from_id == "ip:45.33.32.156"
+        assert reverse.to_id == "domain:li982-156.members.linode.com"
+
+        forward = next(e for e in result.edges if e.label == "RESOLVES_TO")
+        assert forward.from_id == "domain:scanme.nmap.org"
+        assert forward.to_id == "ip:45.33.32.156"
+
+    def test_edges_reference_entities_that_were_imported(self):
+        """Test that every edge endpoint matches an entity in the result."""
+        result = parse_nmap(scanme_report, max_preview_rows=100)
+
+        node_ids = {
+            preview.node_id
+            for entity in result.entities.values()
+            for preview in entity.results
+        }
+        for edge in result.edges:
+            assert edge.from_id in node_ids
+            assert edge.to_id in node_ids
+
+
+class TestMultipleHosts:
+    """Tests for a report covering more than one host."""
+
+    def test_the_same_port_on_two_hosts_stays_two_entities(self):
+        """Test that a port is identified per host, not globally."""
+        result = parse_nmap(subnet_report, max_preview_rows=100)
+
+        node_ids = {p.node_id for p in result.entities["Port"].results}
+        assert "port:10.0.0.1:TCP:80" in node_ids
+
+        has_port = [e for e in result.edges if e.label == "HAS_PORT"]
+        assert {e.from_id for e in has_port} == {"ip:10.0.0.1", "ip:10.0.0.2"}
+
+    def test_tcp_and_udp_on_one_number_stay_separate(self):
+        """Test that the protocol is part of a port's identity."""
+        result = parse_nmap(subnet_report, max_preview_rows=100)
+
+        node_ids = {p.node_id for p in result.entities["Port"].results}
+        assert "port:10.0.0.2:TCP:53" in node_ids
+        assert "port:10.0.0.2:UDP:53" in node_ids
+
+    def test_each_host_keeps_its_own_port_details(self):
+        """Test that one host's findings do not overwrite another's."""
+        result = parse_nmap(subnet_report, max_preview_rows=100)
+
+        by_id = {p.node_id: p.obj for p in result.entities["Port"].results}
+        assert by_id["port:10.0.0.1:TCP:80"].banner == "nginx 1.18.0"
+        assert by_id["port:10.0.0.2:TCP:53"].banner is None
+
+
+class TestHostSelection:
+    """Tests for which hosts are imported at all."""
+
+    def test_hosts_that_are_down_are_not_imported(self):
+        """Test that a host which never answered discovery is skipped."""
+        result = parse_nmap(subnet_report, max_preview_rows=100)
+
+        addresses = {ip.obj.address for ip in result.entities["Ip"].results}
+        assert addresses == {"10.0.0.1", "10.0.0.2"}
+
+    def test_host_state_unknown_is_not_treated_as_up(self):
+        """Test that only an explicit up state counts as scanned."""
+        report = subnet_report.replace(b'state="up"', b'state="unknown"')
+
+        result = parse_nmap(report, max_preview_rows=100)
+
+        assert result.total_entities == 0
+
+    def test_host_without_a_status_element_is_imported(self):
+        """Test that a report with no <status> element still imports."""
+        result = parse_nmap(converted_report, max_preview_rows=100)
+
+        assert result.entities["Ip"].results[0].obj.address == "192.168.1.20"
+
+    def test_ipv6_address_is_imported(self):
+        """Test that an IPv6 host is imported."""
+        result = parse_nmap(ipv6_report, max_preview_rows=100)
+
+        assert (
+            result.entities["Ip"].results[0].obj.address
+            == "2606:2800:220:1:248:1893:25c8:1946"
+        )
+
+    def test_mac_address_is_not_treated_as_the_host(self):
+        """Test that a MAC listed before the IP is not read as the address."""
+        result = parse_nmap(local_report, max_preview_rows=100)
+
+        ips = result.entities["Ip"].results
+        assert len(ips) == 1
+        assert ips[0].obj.address == "192.168.1.10"
+
+    def test_host_with_only_a_mac_address_is_skipped(self):
+        """Test that a host with no IP address is not imported."""
+        report = local_report.replace(
+            b'<address addr="192.168.1.10" addrtype="ipv4"/>', b""
+        )
+
+        result = parse_nmap(report, max_preview_rows=100)
+
+        assert result.total_entities == 0
+
+    def test_extraports_do_not_become_entities(self):
+        """Test that the <extraports> count is not expanded into nodes."""
+        result = parse_nmap(scanme_report, max_preview_rows=100)
+
+        assert len(result.entities["Port"].results) == 4
+        assert all(port.obj.number != 996 for port in result.entities["Port"].results)
+
+    def test_unparseable_hostname_is_skipped_not_fatal(self):
+        """Test that a name the Domain type rejects does not fail the import."""
+        report = scanme_report.replace(b'name="scanme.nmap.org"', b'name="localhost"')
+
+        result = parse_nmap(report, max_preview_rows=100)
+
+        domains = {d.obj.domain for d in result.entities["Domain"].results}
+        assert domains == {"li982-156.members.linode.com"}
+        assert len(result.entities["Ip"].results) == 1
+
+
+class TestPreviewLimit:
+    """Tests for max_preview_rows."""
+
+    def test_entities_are_capped(self):
+        """Test that the parser stops at the requested number of entities."""
+        result = parse_nmap(scanme_report, max_preview_rows=3)
+
+        assert result.total_entities == 3
+        assert sum(len(e.results) for e in result.entities.values()) == 3
+
+    def test_edges_never_dangle_when_capped(self):
+        """Test that an edge is only emitted if both endpoints survived."""
+        result = parse_nmap(scanme_report, max_preview_rows=3)
+
+        node_ids = {
+            preview.node_id
+            for entity in result.entities.values()
+            for preview in entity.results
+        }
+        for edge in result.edges:
+            assert edge.from_id in node_ids
+            assert edge.to_id in node_ids
+
+    def test_a_cap_stops_later_hosts(self):
+        """Test that the cap applies across hosts, not per host."""
+        result = parse_nmap(subnet_report, max_preview_rows=2)
+
+        assert result.total_entities == 2
+
+
+class TestEdgeCases:
+    """Tests for malformed and hostile input."""
+
+    def test_empty_file(self):
+        """Test that an empty upload is rejected with a readable message."""
+        with pytest.raises(ValueError) as exc_info:
+            parse_nmap(b"", max_preview_rows=100)
+
+        assert "empty" in str(exc_info.value).lower()
+
+    def test_whitespace_only_file(self):
+        """Test that a whitespace-only upload is rejected."""
+        with pytest.raises(ValueError) as exc_info:
+            parse_nmap(b"   \n\t  ", max_preview_rows=100)
+
+        assert "empty" in str(exc_info.value).lower()
+
+    def test_invalid_xml(self):
+        """Test that broken XML raises ValueError rather than crashing."""
+        with pytest.raises(ValueError) as exc_info:
+            parse_nmap(b"<nmaprun><host>", max_preview_rows=100)
+
+        assert "invalid xml" in str(exc_info.value).lower()
+
+    def test_unknown_encoding_declaration(self):
+        """Test that an unknown encoding is a parse error, not a server error."""
+        report = (
+            b'<?xml version="1.0" encoding="NOPE"?>'
+            b'<nmaprun scanner="nmap"><host/></nmaprun>'
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            parse_nmap(report, max_preview_rows=100)
+
+        assert "invalid xml" in str(exc_info.value).lower()
+
+    def test_xml_that_is_not_an_nmap_report(self):
+        """Test that a valid XML document with the wrong root is refused."""
+        with pytest.raises(ValueError) as exc_info:
+            parse_nmap(
+                b"<?xml version='1.0'?><rss><channel/></rss>", max_preview_rows=100
+            )
+
+        assert "nmaprun" in str(exc_info.value)
+
+    def test_report_with_no_hosts(self):
+        """Test that a report containing no host has nothing to import."""
+        report = b'<?xml version="1.0"?><nmaprun scanner="nmap"><runstats/></nmaprun>'
+
+        with pytest.raises(ValueError) as exc_info:
+            parse_nmap(report, max_preview_rows=100)
+
+        assert "no <host>" in str(exc_info.value)
+
+    def test_entity_declaration_is_refused(self):
+        """Test that an entity declaration is refused, as nmap never writes one."""
+        report = b"""<?xml version="1.0"?>
+<!DOCTYPE nmaprun [
+  <!ENTITY lol "lollollollollollollollol">
+]>
+<nmaprun scanner="nmap"><host><status state="up"/><address addr="1.1.1.1" addrtype="ipv4"/></host></nmaprun>"""
+
+        with pytest.raises(ValueError) as exc_info:
+            parse_nmap(report, max_preview_rows=100)
+
+        assert "EntitiesForbidden" in str(exc_info.value)
+
+    def test_entity_declaration_is_refused_in_utf16(self):
+        """Test that the refusal does not depend on the document's encoding.
+
+        A byte-level scan for the literal `<!ENTITY` misses a UTF-16 document,
+        where the same declaration is encoded with interleaved null bytes, so
+        the refusal has to happen in the parser.
+        """
+        report = """<?xml version="1.0" encoding="UTF-16"?>
+<!DOCTYPE nmaprun [
+  <!ENTITY a "AAAAAAAAAA">
+  <!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">
+]>
+<nmaprun scanner="nmap"><host><status state="up"/>
+<address addr="1.1.1.1" addrtype="ipv4"/>
+<ports><port protocol="tcp" portid="80"><state state="open"/>
+<service name="&b;" method="probed" product="&b;"/></port></ports>
+</host></nmaprun>""".encode("utf-16")
+
+        assert b"<!ENTITY" not in report
+
+        with pytest.raises(ValueError) as exc_info:
+            parse_nmap(report, max_preview_rows=100)
+
+        assert "EntitiesForbidden" in str(exc_info.value)
+
+    def test_external_entity_is_refused(self):
+        """Test that an entity which would read a local file is refused."""
+        report = (
+            b'<?xml version="1.0"?>\n'
+            b'<!DOCTYPE nmaprun [ <!ENTITY xxe SYSTEM "file:///etc/passwd"> ]>\n'
+            b'<nmaprun scanner="nmap"><host><status state="up"/>'
+            b'<address addr="&xxe;" addrtype="ipv4"/></host></nmaprun>'
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            parse_nmap(report, max_preview_rows=100)
+
+        assert "refused" in str(exc_info.value).lower()
+
+    def test_bare_doctype_is_accepted(self):
+        """Test that nmap's own <!DOCTYPE nmaprun> still parses."""
+        result = parse_nmap(scanme_report, max_preview_rows=100)
+
+        assert result.total_entities == 7
+
+    def test_oversized_file_is_refused(self):
+        """Test that a very large upload is refused rather than parsed."""
+        report = b"<nmaprun>" + b" " * (MAX_FILE_BYTES + 1) + b"</nmaprun>"
+
+        with pytest.raises(ValueError) as exc_info:
+            parse_nmap(report, max_preview_rows=100)
+
+        assert "larger than" in str(exc_info.value).lower()
+
+    def test_port_number_out_of_range_is_skipped(self):
+        """Test that a port number outside 0-65535 does not fail the import."""
+        report = scanme_report.replace(b'portid="80"', b'portid="99999"')
+
+        result = parse_nmap(report, max_preview_rows=100)
+
+        assert {p.obj.number for p in result.entities["Port"].results} == {22, 25, 443}
+
+    def test_non_numeric_port_id_is_skipped(self):
+        """Test that a non-numeric portid is skipped rather than coerced."""
+        report = scanme_report.replace(b'portid="80"', b'portid="http"')
+
+        result = parse_nmap(report, max_preview_rows=100)
+
+        assert {p.obj.number for p in result.entities["Port"].results} == {22, 25, 443}
+
+    def test_host_without_an_ip_address_is_skipped(self):
+        """Test that a host element with no IP address is not imported."""
+        report = b"""<?xml version="1.0"?>
+<nmaprun scanner="nmap"><host><status state="up"/><ports>
+<port protocol="tcp" portid="80"><state state="open"/></port>
+</ports></host></nmaprun>"""
+
+        result = parse_nmap(report, max_preview_rows=100)
+
+        assert result.total_entities == 0
+        assert result.edges == []
+
+
+class TestIntegration:
+    """Integration tests with parse_import_file."""
+
+    def test_parse_import_file_dispatches_on_xml(self):
+        """Test the full import pipeline with an nmap XML file."""
+        result = parse_import_file(scanme_report, "scan.xml", max_preview_rows=100)
+
+        assert result.total_entities == 7
+        assert "Ip" in result.entities
+        assert "Port" in result.entities
+
+    def test_uppercase_extension_is_accepted(self):
+        """Test that the extension is lowercased before dispatch."""
+        result = parse_import_file(scanme_report, "SCAN.XML", max_preview_rows=100)
+
+        assert result.total_entities == 7

--- a/uv.lock
+++ b/uv.lock
@@ -795,6 +795,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "detect-installer"
 version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1191,6 +1200,7 @@ dependencies = [
     { name = "bcrypt" },
     { name = "celery" },
     { name = "cryptography" },
+    { name = "defusedxml" },
     { name = "docker" },
     { name = "flowsint-enrichers" },
     { name = "httpx" },
@@ -1230,6 +1240,7 @@ requires-dist = [
     { name = "bcrypt", specifier = ">=4.0.0,<5.0.0" },
     { name = "celery", specifier = ">=5.3,<6.0" },
     { name = "cryptography", specifier = ">=48.0.1,<49.0.0" },
+    { name = "defusedxml", specifier = ">=0.7,<0.8" },
     { name = "docker", specifier = ">=7.1.0,<8.0.0" },
     { name = "flowsint-enrichers", editable = "flowsint-enrichers" },
     { name = "httpx", specifier = ">=0.28,<0.29" },


### PR DESCRIPTION
Closes #107.

> **Note on #184.** @rachit367 opened a PR for this in June that I didn't see before starting — I looked at the issue thread rather than its linked PRs, which was my mistake. I've commented there with the differences. I'm happy to close this in favour of #184, or to contribute the tests and the state/banner handling to that branch instead — whichever the maintainers prefer.

Imports an nmap XML report (`nmap -oX`) that the investigator produced themselves, so a sketch can be enriched from a scan that was already run rather than scanning the target again. It goes through the existing import path — no new active-collection surface.

## Mapping

Matches the shape the naabu enricher already produces:

- each host reported up → `Ip`
- each `<hostname>` → `Domain`, with `REVERSE_RESOLVES_TO` for a PTR record and `RESOLVES_TO` for a name given on the command line
- each `<port>` → `Port`, linked `HAS_PORT` from its host

## Two deliberate differences from naabu

Both are about not overstating what a scan found:

- **Port state is carried through verbatim** rather than flattened to open, so `filtered` stays distinguishable from `closed`.
- **`banner` is only set when nmap actually fingerprinted the service.** A service name guessed from the port number isn't presented as an identified one, and a TLS-wrapped service reads as `ssl/http`, the way nmap's own output prints it.

## Security

Parsing goes through `defusedxml`. An uploaded report is untrusted input, and its service banners are whatever the scanned hosts sent back.

## Known limitation — port identity is not host-scoped

I want to flag this rather than have it surface in review.

`repository.py` MERGEs on `(nodeLabel, sketch_id)`, and `Port.compute_label` builds the label from number + service + protocol with **no host in it**. So two hosts in one report that both have `80/tcp/http` collapse into a single shared `Port` node, and `SET n += $props` means the last host in the file wins its state and banner. I reproduced this end to end against the existing MERGE semantics: host A's port 80 `open`/`nginx` was overwritten to `filtered`/`null` by host B.

**This is pre-existing** — the naabu enricher uses the identical MERGE. But this PR is what makes it reachable: naabu hardcodes `state="open"` and runs one IP at a time, so conflicting states weren't previously possible. A `/24` scan is the ordinary way people use nmap, and it's the first thing anyone will feed this.

The parser can't fix it. The label is computed by `Port.compute_label` in `flowsint-types`, and changing it would change the naabu enricher's node identity too — that's a maintainer's call, not a first-PR call. Happy to follow up with it if you tell me which way you want it to go.

## Tests

637 lines covering the mapping, port-state handling, banner suppression, PTR vs command-line hostname edge direction, and malformed/hostile XML.
