### PR TITLE
feat(types): detect @-prefixed usernames on import

### DIFF
--- a/flowsint-types/src/flowsint_types/username.py
+++ b/flowsint-types/src/flowsint_types/username.py
@@ -36,7 +36,7 @@ class Username(FlowsintType):
         - Hyphens (-)
         """
         if v.startswith("@"):
-            v = v[1:]  # We remove it
+            v = v[1:]
         # if not re.match(r"^[a-zA-Z0-9_-]{3,80}$", v):
         #     raise ValueError(
         #         f"Invalid username: {v}. Must be 3-80 characters and contain only letters, numbers, underscores, and hyphens."
@@ -55,16 +55,21 @@ class Username(FlowsintType):
 
     @classmethod
     def detect(cls, line: str) -> bool:
-        """Detect if a line of text contains a username."""
+        """Detect whether a line of text contains a username."""
         line = line.strip()
         if not line:
             return False
 
-        # Don't claim file hashes (MD5/SHA1/SHA256) — those are File entities.
-        # This keeps hash detection independent of type-registration order.
-        if len(line) in (32, 40, 64) and re.fullmatch(r"[0-9a-fA-F]+", line):
+        # Support one leading '@' prefix, which is common for social handles.
+        raw = line[1:] if line.startswith("@") else line
+        if not raw:
             return False
 
-        # Username pattern: 3-80 characters, only letters, numbers, underscores, hyphens
-        # Note: This is intentionally restrictive to avoid false positives
-        return bool(re.match(r"^[a-zA-Z0-9_-]{3,80}$", line))
+        # Don't claim file hashes (MD5/SHA1/SHA256) — those are File entities.
+        # This keeps hash detection independent of type-registration order.
+        if len(raw) in (32, 40, 64) and re.fullmatch(r"[0-9a-fA-F]+", raw):
+            return False
+
+        # Username pattern: 3-80 characters, only letters, numbers, underscores, hyphens.
+        # This is intentionally restrictive to avoid false positives.
+        return bool(re.fullmatch(r"[a-zA-Z0-9_-]{3,80}", raw))

--- a/flowsint-types/tests/test_username.py
+++ b/flowsint-types/tests/test_username.py
@@ -1,0 +1,31 @@
+"""Regression tests for @-prefixed username detection."""
+
+from flowsint_types import Username
+
+
+def test_detects_plain_and_at_prefixed_usernames():
+    assert Username.detect("johnDoe") is True
+    assert Username.detect("user_123") is True
+    assert Username.detect("@johnDoe") is True
+    assert Username.detect("@user_123") is True
+    assert Username.detect("  @test-user  ") is True
+
+
+def test_rejects_invalid_or_incomplete_at_prefixed_values():
+    assert Username.detect("@") is False
+    assert Username.detect("@ab") is False
+    assert Username.detect("@@johnDoe") is False
+    assert Username.detect("@john doe") is False
+    assert Username.detect("@user@domain") is False
+
+
+def test_rejects_hashes_with_or_without_at_prefix():
+    md5 = "d41d8cd98f00b204e9800998ecf8427e"
+    assert Username.detect(md5) is False
+    assert Username.detect(f"@{md5}") is False
+
+
+def test_from_string_normalizes_at_prefix():
+    username = Username.from_string("  @johnDoe  ")
+    assert username.value == "johnDoe"
+    assert username.nodeLabel == "johnDoe"


### PR DESCRIPTION
## Summary

Closes #204.

This change recognizes social handles with a single leading `@` during username detection, so `.txt` imports classify entries such as `@johnDoe` as `Username` rather than `Unknown`.

## Implementation

- Normalize one leading `@` before checking the username pattern.
- Preserve the existing 3–80 character limit and allowed character set.
- Keep MD5, SHA-1, and SHA-256 detection independent by excluding hashes with or without an `@` prefix.
- Retain `Username.from_string()` normalization so stored values and node labels omit the prefix.

## Tests

Added focused regression coverage for plain and `@`-prefixed handles, whitespace trimming, invalid prefixes, hash rejection, and normalized stored values.
